### PR TITLE
alias for unit processing functions

### DIFF
--- a/brainunit/_base.py
+++ b/brainunit/_base.py
@@ -36,9 +36,13 @@ __all__ = [
     'Unit',
     'Quantity',
 
-    # helpers
+    # errors
     'DimensionMismatchError',
     'UnitMismatchError',
+    'DIMENSIONLESS',
+    'UNITLESS',
+
+    # helpers
     'is_dimensionless',
     'is_unitless',
     'get_dim',
@@ -47,10 +51,6 @@ __all__ = [
     'get_magnitude',
     'display_in_unit',
     'maybe_decimal',
-
-    # helper classes
-    'DIMENSIONLESS',
-    'UNITLESS',
 
     # functions for checking
     'check_dims',

--- a/brainunit/math/__init__.py
+++ b/brainunit/math/__init__.py
@@ -15,6 +15,8 @@
 
 from ._activation import *
 from ._activation import __all__ as _activation_all
+from ._alias import *
+from ._alias import __all__ as _alias_all
 from ._einops import *
 from ._einops import __all__ as _einops_all
 from ._fun_accept_unitless import *
@@ -31,6 +33,7 @@ from ._misc import *
 from ._misc import __all__ as _compat_misc_all
 
 __all__ = (_compat_array_creation_all +
+           _alias_all +
            _compat_funcs_change_unit_all +
            _compat_funcs_keep_unit_all +
            _compat_funcs_accept_unitless_all +
@@ -40,6 +43,7 @@ __all__ = (_compat_array_creation_all +
            _activation_all)
 
 del (_compat_array_creation_all,
+     _alias_all,
      _compat_funcs_change_unit_all,
      _compat_funcs_keep_unit_all,
      _compat_funcs_accept_unitless_all,

--- a/brainunit/math/_alias.py
+++ b/brainunit/math/_alias.py
@@ -1,0 +1,41 @@
+# Copyright 2024 BDP Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+
+from brainunit._base import (is_dimensionless, is_unitless, get_dim, get_unit, get_mantissa, get_magnitude,
+                             display_in_unit, maybe_decimal, check_dims, check_units,
+                             fail_for_dimension_mismatch, fail_for_unit_mismatch,
+                             assert_quantity, get_or_create_dimension)
+
+__all__ = [
+    'is_dimensionless',
+    'is_unitless',
+    'get_dim',
+    'get_unit',
+    'get_mantissa',
+    'get_magnitude',
+    'display_in_unit',
+    'maybe_decimal',
+
+    # functions for checking
+    'check_dims',
+    'check_units',
+    'fail_for_dimension_mismatch',
+    'fail_for_unit_mismatch',
+    'assert_quantity',
+
+    # advanced functions
+    'get_or_create_dimension',
+]

--- a/docs/apis/brainunit.rst
+++ b/docs/apis/brainunit.rst
@@ -6,8 +6,8 @@
 
 
 
-Base Classes
-------------
+Data Structures
+---------------
 
 .. autosummary::
    :toctree: generated/
@@ -16,26 +16,17 @@ Base Classes
 
     Quantity
     Unit
-    UnitMismatchError
     Dimension
-    DimensionMismatchError
 
 
-Helper Functions
-----------------
+Errors
+------
 
 .. autosummary::
    :toctree: generated/
    :nosignatures:
    :template: classtemplate.rst
 
-    get_or_create_dimension
-    get_unit
-    get_dim
-    is_unitless
-    is_dimensionless
-    check_dims
-    check_units
-    fail_for_dimension_mismatch
-    fail_for_unit_mismatch
+    UnitMismatchError
+    DimensionMismatchError
 

--- a/docs/auto_generater.py
+++ b/docs/auto_generater.py
@@ -311,6 +311,7 @@ def main():
                 template=True)
 
   module_and_name = [
+    ('_alias', 'Unit Processing'),
     ('_einops', 'Einstein Operations'),
     ('_fun_accept_unitless', 'Functions that Accepting Unitless'),
     ('_fun_array_creation', 'Array Creation Functions'),


### PR DESCRIPTION
This pull request includes several changes to the `brainunit` package, focusing on organizing imports, updating documentation, and adding a new module. The most important changes include the addition of the `_alias` module, reorganization of imports, and updates to the documentation structure.

### New module addition:

* [`brainunit/math/_alias.py`](diffhunk://#diff-ffaea69e61bb2cbc9e8cfa5f229513fd53c3dc8e2b24c5b52d09b9663ce865a4R1-R41): Added a new module `_alias` with relevant imports and functions.

### Reorganization of imports:

* [`brainunit/math/__init__.py`](diffhunk://#diff-1ea11655b5c18f4e63b0fe36f8e77b138cec7f23e5717a04fe5f7a5c3b5876b6R18-R19): Added imports from the new `_alias` module and updated the `__all__` list to include `_alias_all`. [[1]](diffhunk://#diff-1ea11655b5c18f4e63b0fe36f8e77b138cec7f23e5717a04fe5f7a5c3b5876b6R18-R19) [[2]](diffhunk://#diff-1ea11655b5c18f4e63b0fe36f8e77b138cec7f23e5717a04fe5f7a5c3b5876b6R36) [[3]](diffhunk://#diff-1ea11655b5c18f4e63b0fe36f8e77b138cec7f23e5717a04fe5f7a5c3b5876b6R46)
* [`brainunit/_base.py`](diffhunk://#diff-68f3b161fe7a5ee956cf1363f0ef9df0fda8ce903c36894fadc791ab363e9c57L39-R45): Moved `DIMENSIONLESS` and `UNITLESS` to the errors section and adjusted the order of helper functions. [[1]](diffhunk://#diff-68f3b161fe7a5ee956cf1363f0ef9df0fda8ce903c36894fadc791ab363e9c57L39-R45) [[2]](diffhunk://#diff-68f3b161fe7a5ee956cf1363f0ef9df0fda8ce903c36894fadc791ab363e9c57L51-L54)

### Documentation updates:

* [`docs/apis/brainunit.rst`](diffhunk://#diff-e35dcd15f2ebfd56de4021f9ece6567d212d64c642bf407097e3bb8fadbb13cfL9-R10): Updated section titles and moved `UnitMismatchError` and `DimensionMismatchError` to the new "Errors" section. [[1]](diffhunk://#diff-e35dcd15f2ebfd56de4021f9ece6567d212d64c642bf407097e3bb8fadbb13cfL9-R10) [[2]](diffhunk://#diff-e35dcd15f2ebfd56de4021f9ece6567d212d64c642bf407097e3bb8fadbb13cfL19-R31)
* [`docs/auto_generater.py`](diffhunk://#diff-8185226506b79495f81d2193ae6cb66e8df6d6d43c58b3b49d04930cebcb175aR314): Added `_alias` to the `module_and_name` list for documentation generation.