### PR TITLE
[base] Override `__format__` method of `Quantity`

### DIFF
--- a/brainunit/_base.py
+++ b/brainunit/_base.py
@@ -2447,6 +2447,14 @@ class Quantity:
         # which should be more clear when add a "*" operator
         return self.repr_in_unit(python_code=True)
 
+    def __format__(self, format_spec):
+        # check if scalar
+        if self.shape == ():
+            formatted_value = format(self.mantissa, format_spec)
+            return f"{formatted_value} * {self.unit}"
+        else:
+            return self.__str__()
+
     def __iter__(self):
         """Solve the issue of DeviceArray.__iter__.
 

--- a/brainunit/_base.py
+++ b/brainunit/_base.py
@@ -2451,9 +2451,16 @@ class Quantity:
         # check if scalar
         if self.shape == ():
             formatted_value = format(self.mantissa, format_spec)
-            return f"{formatted_value} * {self.unit}"
+            return f"{formatted_value} * {self.unit.name}"
         else:
-            return self.__str__()
+            try:
+                # Extract the number of decimal places from the format_spec
+                decimal_places = int(format_spec.strip('f').strip('.'))
+
+                rounded_value = self.round(decimal_places)
+                return rounded_value.__repr__()
+            except:
+                return self.__repr__()
 
     def __iter__(self):
         """Solve the issue of DeviceArray.__iter__.

--- a/brainunit/_base_test.py
+++ b/brainunit/_base_test.py
@@ -16,8 +16,6 @@
 
 import os
 
-from brainunit import UnitMismatchError
-
 os.environ['JAX_TRACEBACK_FILTERING'] = 'off'
 import itertools
 import unittest

--- a/brainunit/_base_test.py
+++ b/brainunit/_base_test.py
@@ -1535,7 +1535,13 @@ class TestGetMethod(unittest.TestCase):
         assert u.get_mantissa(u.mV.dim ** 2 / u.second.dim ** 2) == u.mV.dim ** 2 / u.second.dim ** 2
 
     def test_format(self):
-        q = 1.23456789 * u.mV
-        assert f"{q:.2f}" == "1.23 * mV"
-        assert f"{q:.3f}" == "1.235 * mV"
-        assert f"{q:.4f}" == "1.2346 * mV"
+        with bst.environ.context(precision=64):
+            q1 = 1.23456789 * u.mV
+            assert f"{q1:.2f}" == "1.23 * mvolt"
+            assert f"{q1:.3f}" == "1.235 * mvolt"
+            assert f"{q1:.4f}" == "1.2346 * mvolt"
+
+            q2 = [1.23456789, 1.23456789] * u.mV
+            assert f"{q2:.2f}" == "ArrayImpl([1.23, 1.23]) * mvolt"
+            assert f"{q2:.3f}" == "ArrayImpl([1.235, 1.235]) * mvolt"
+            assert f"{q2:.4f}" == "ArrayImpl([1.2346, 1.2346]) * mvolt"

--- a/brainunit/_base_test.py
+++ b/brainunit/_base_test.py
@@ -16,6 +16,8 @@
 
 import os
 
+from brainunit import UnitMismatchError
+
 os.environ['JAX_TRACEBACK_FILTERING'] = 'off'
 import itertools
 import unittest
@@ -1209,7 +1211,7 @@ class TestHelperFunctions(unittest.TestCase):
             a_function(5 * second, None)
         with pytest.raises(DimensionMismatchError):
             a_function(5, None)
-        with pytest.raises(AttributeError):
+        with pytest.raises(DimensionMismatchError):
             a_function(object(), None)
         with pytest.raises(TypeError):
             a_function([1, 2 * volt, 3], None)
@@ -1277,7 +1279,7 @@ class TestHelperFunctions(unittest.TestCase):
             a_function(5 * second, None)
         with pytest.raises(u.UnitMismatchError):
             a_function(5, None)
-        with pytest.raises(AttributeError):
+        with pytest.raises(u.UnitMismatchError):
             a_function(object(), None)
         with pytest.raises(TypeError):
             a_function([1, 2 * volt, 3], None)
@@ -1531,3 +1533,9 @@ class TestGetMethod(unittest.TestCase):
         assert u.get_mantissa(u.mV.dim / u.second.dim) == u.mV.dim / u.second.dim
         assert u.get_mantissa(u.mV.dim / u.second.dim ** 2) == u.mV.dim / u.second.dim ** 2
         assert u.get_mantissa(u.mV.dim ** 2 / u.second.dim ** 2) == u.mV.dim ** 2 / u.second.dim ** 2
+
+    def test_format(self):
+        q = 1.23456789 * u.mV
+        assert f"{q:.2f}" == "1.23 * mV"
+        assert f"{q:.3f}" == "1.235 * mV"
+        assert f"{q:.4f}" == "1.2346 * mV"


### PR DESCRIPTION
This pull request introduces a new `__format__` method for the `brainunit` module and updates the corresponding tests. The most important changes include adding the `__format__` method to handle scalar and non-scalar values, updating test cases to reflect the new method, and importing a new error type in the test file.

Enhancements to formatting:

* [`brainunit/_base.py`](diffhunk://#diff-68f3b161fe7a5ee956cf1363f0ef9df0fda8ce903c36894fadc791ab363e9c57R2450-R2464): Added a `__format__` method to handle scalar and non-scalar values, allowing for custom formatting of the mantissa and unit.

Updates to test cases:

* [`brainunit/_base_test.py`](diffhunk://#diff-9199ab763579fad8135030608ccb80ba262d9393ae15663e0678ee20c3fb9e91R1536-R1547): Added a new test case `test_format` to verify the functionality of the `__format__` method with different precision levels.
* [`brainunit/_base_test.py`](diffhunk://#diff-9199ab763579fad8135030608ccb80ba262d9393ae15663e0678ee20c3fb9e91L1212-R1214): Updated existing test cases to use `UnitMismatchError` instead of `AttributeError` for better error handling. [[1]](diffhunk://#diff-9199ab763579fad8135030608ccb80ba262d9393ae15663e0678ee20c3fb9e91L1212-R1214) [[2]](diffhunk://#diff-9199ab763579fad8135030608ccb80ba262d9393ae15663e0678ee20c3fb9e91L1280-R1282)
