### PR TITLE
Add unit-aware gradients and corresponding documentation

### DIFF
--- a/brainunit/__init__.py
+++ b/brainunit/__init__.py
@@ -19,6 +19,7 @@ from . import _matplotlib_compat
 from . import lax
 from . import math
 from . import linalg
+from . import autograd
 from ._base import *
 from ._base import __all__ as _base_all
 from ._celsius import *
@@ -30,5 +31,5 @@ from ._unit_constants import __all__ as _constants_all
 from ._unit_shortcuts import *
 from ._unit_shortcuts import __all__ as _std_units_all
 
-__all__ = ['math'] + _common_all + _std_units_all + _constants_all + _base_all + _celsius_all
+__all__ = ['math', 'linalg', 'autograd'] + _common_all + _std_units_all + _constants_all + _base_all + _celsius_all
 del _common_all, _std_units_all, _constants_all, _base_all, _celsius_all, _matplotlib_compat

--- a/brainunit/_base.py
+++ b/brainunit/_base.py
@@ -3206,7 +3206,7 @@ class Quantity:
         r = jnp.repeat(self.mantissa, repeats=repeats, axis=axis)
         return Quantity(r, unit=self.unit)
 
-    def reshape(self, *shape, order='C') -> 'Quantity':
+    def reshape(self, shape, order='C') -> 'Quantity':
         """Returns an array containing the same data with a new shape."""
         return Quantity(jnp.reshape(self.mantissa, shape, order=order), unit=self.unit)
 

--- a/brainunit/autograd/__init__.py
+++ b/brainunit/autograd/__init__.py
@@ -1,0 +1,30 @@
+# Copyright 2024 BDP Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+
+__all__ = [
+    'value_and_grad',
+    'grad',
+    'vector_grad',
+    'jacobian',
+    'jacrev',
+    'jacfwd',
+    'hessian',
+]
+
+from ._hessian import *
+from ._jacobian import *
+from ._value_and_grad import *
+from ._vector_grad import *

--- a/brainunit/autograd/_hessian.py
+++ b/brainunit/autograd/_hessian.py
@@ -1,0 +1,58 @@
+# Copyright 2024 BDP Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from typing import (Sequence, Callable)
+
+from ._jacobian import jacrev, jacfwd
+from ._misc import _check_callable
+
+__all__ = [
+    'hessian'
+]
+
+
+def hessian(
+    fun: Callable,
+    argnums: int | Sequence[int] = 0,
+    has_aux: bool = False,
+    holomorphic: bool = False
+) -> Callable:
+    """
+    Physical unit-aware version of `jax.hessian <https://jax.readthedocs.io/en/latest/_autosummary/jax.hessian.html>`_,
+    computing Hessian of ``fun`` as a dense array.
+
+    Args:
+      fun: Function whose Hessian is to be computed.  Its arguments at positions
+        specified by ``argnums`` should be arrays, scalars, or standard Python
+        containers thereof. It should return arrays, scalars, or standard Python
+        containers thereof.
+      argnums: Optional, integer or sequence of integers. Specifies which
+        positional argument(s) to differentiate with respect to (default ``0``).
+      has_aux: Optional, bool. Indicates whether ``fun`` returns a pair where the
+        first element is considered the output of the mathematical function to be
+        differentiated and the second element is auxiliary data. Default False.
+      holomorphic: Optional, bool. Indicates whether ``fun`` is promised to be
+        holomorphic. Default False.
+
+    Returns:
+      A function with the same arguments as ``fun``, that evaluates the Hessian of
+      ``fun``.
+    """
+    _check_callable(fun)
+
+    return jacfwd(
+        jacrev(fun, argnums, has_aux=has_aux, holomorphic=holomorphic),
+        argnums, has_aux=has_aux, holomorphic=holomorphic,
+    )

--- a/brainunit/autograd/_hessian_test.py
+++ b/brainunit/autograd/_hessian_test.py
@@ -1,0 +1,121 @@
+# Copyright 2024 BDP Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+
+import unittest
+
+import jax
+import numpy as np
+
+import brainunit as u
+
+
+class TestHessianFunction(unittest.TestCase):
+    def test_hessian_scalar_function(self):
+        def scalar_function(x):
+            return x ** 2 + 3 * x + 2
+
+        hess = u.autograd.hessian(scalar_function)
+        x = np.array(1.0)
+        expected_hessian = np.array([[2.0]])
+        np.testing.assert_array_almost_equal(hess(x), expected_hessian)
+
+    def test_hessian_scalar_function_with_unit(self):
+        unit = u.ms
+
+        def scalar_function(x):
+            return x ** 2 + 3 * x * unit + 2 * unit * unit
+
+        hess = u.autograd.hessian(scalar_function)
+        x = np.array(1.0) * unit
+        res = hess(x)
+        expected_hessian = np.array([[2.0]])
+        np.testing.assert_array_almost_equal(res, expected_hessian)
+
+    def test_hessian_scalar_function_with_unit2(self):
+        unit = u.ms
+
+        def scalar_function(x):
+            return x ** 3 + 3 * x * unit * unit + 2 * unit * unit * unit
+
+        hess = u.autograd.hessian(scalar_function)
+        x = np.array(1.0) * unit
+        res = hess(x)
+        expected_hessian = np.array([[6.0]]) * unit
+        assert u.math.allclose(res, expected_hessian)
+
+    def test_hessian_vector_function(self):
+        def vector_function(x):
+            return np.sum(x ** 2)
+
+        hess = u.autograd.hessian(vector_function)
+        x = np.array([1.0, 2.0])
+        expected_hessian = np.array([[2.0, 0.0], [0.0, 2.0]])
+        np.testing.assert_array_almost_equal(hess(x), expected_hessian)
+
+    def test_hessian_with_aux(self):
+        unit = u.ms
+
+        def function_with_aux(x):
+            return x ** 2, x + u.math.ones_like(x)
+
+        hess = u.autograd.hessian(function_with_aux, has_aux=True)
+        x = np.array(1.0)
+        expected_hessian = np.array([[2.0]])
+        result, aux = hess(x)
+        np.testing.assert_array_almost_equal(result, expected_hessian)
+        np.testing.assert_array_almost_equal(aux, np.array(2.0))
+
+        x = np.array(1.0) * unit
+        result, aux = hess(x)
+        expected_hessian = np.array([[2.0]])
+        assert u.math.allclose(result, expected_hessian)
+        assert u.math.allclose(aux, np.array(2.0) * unit)
+
+    def test_hessian_multiple_arguments(self):
+        def multi_arg_function(x, y):
+            return x ** 2 + y ** 2
+
+        hess = u.autograd.hessian(multi_arg_function, argnums=(0, 1))
+        x = np.array(1.0)
+        y = np.array(2.0)
+        expected_hessian = np.array([[2.0, 0.0], [0.0, 2.0]])
+        res = hess(x, y)
+        np.testing.assert_array_almost_equal(res, expected_hessian)
+
+        x = np.array(1.0) * u.ms
+        y = np.array(2.0) * u.ms
+        res = hess(x, y)
+        assert u.math.allclose(u.math.asarray(res), expected_hessian)
+
+    def test_hessian_dict(self):
+        def dict_function(x):
+            return {'z': x['a'] ** 3 + x['b'] ** 3}
+
+        unit = u.ms
+        x = {'a': np.array(1.0) * unit, 'b': np.array(2.0) * unit}
+        res = u.autograd.hessian(dict_function)(x)
+
+        expected_hessian = {'z': {'a': {'a': 6.0 * unit, 'b': 0.0 * unit},
+                                  'b': {'a': 0.0 * unit, 'b': 12.0 * unit}}}
+
+        def check(a, b):
+            assert u.math.allclose(a, b)
+
+        jax.tree.map(check, res, expected_hessian, is_leaf=u.math.is_quantity)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/brainunit/autograd/_jacobian.py
+++ b/brainunit/autograd/_jacobian.py
@@ -1,0 +1,262 @@
+# Copyright 2024 BDP Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from __future__ import annotations
+
+from functools import wraps, partial
+from typing import (Sequence, Callable, Any)
+
+import jax
+import numpy as np
+from jax._src.api import (_jvp,
+                          _vjp,
+                          _check_input_dtype_jacrev,
+                          _check_output_dtype_jacrev,
+                          _check_input_dtype_jacfwd,
+                          _check_output_dtype_jacfwd)
+from jax.api_util import argnums_partial
+from jax.extend import linear_util
+
+from brainunit._base import Quantity, maybe_decimal, get_magnitude, get_unit
+from ._misc import _ensure_index, _check_callable
+
+__all__ = [
+    'jacrev',
+    'jacfwd',
+    'jacobian',
+]
+
+
+def jacrev(
+    fun: Callable,
+    argnums: int | Sequence[int] = 0,
+    has_aux: bool = False,
+    holomorphic: bool = False,
+    allow_int: bool = False
+) -> Callable:
+    """
+    Physical unit-aware version of `jax.jacrev <https://jax.readthedocs.io/en/latest/_autosummary/jax.jacrev.html>`_.
+
+    Args:
+        fun: Function whose Jacobian is to be computed.
+        argnums: Optional, integer or sequence of integers. Specifies which
+            positional argument(s) to differentiate with respect to (default ``0``).
+        has_aux: Optional, bool. Indicates whether ``fun`` returns a pair where the
+            first element is considered the output of the mathematical function to be
+            differentiated and the second element is auxiliary data. Default False.
+        holomorphic: Optional, bool. Indicates whether ``fun`` is promised to be holomorphic. Default False.
+        allow_int: Optional, bool. Indicates whether integer arguments are allowed. Default False.
+
+    Returns:
+        A function that computes the Jacobian of ``fun`` through reverse-mode automatic differentiation.
+    """
+    _check_callable(fun)
+
+    @wraps(fun)
+    def jacfun(*args, **kwargs):
+        f = linear_util.wrap_init(fun, kwargs)
+        f_partial, dyn_args = argnums_partial(f, argnums, args, require_static_args_hashable=False)
+        jax.tree.map(partial(_check_input_dtype_jacrev, holomorphic, allow_int), dyn_args)
+        if not has_aux:
+            y, pullback = _vjp(f_partial, *dyn_args)
+        else:
+            y, pullback, aux = _vjp(f_partial, *dyn_args, has_aux=True)
+        jax.tree.map(partial(_check_output_dtype_jacrev, holomorphic), y)
+        jac = jax.vmap(pullback)(_std_basis(y))
+        jac = jac[0] if isinstance(argnums, int) else jac
+        jac_tree = jax.tree.map(partial(_jacrev_unravel, y, is_leaf=_is_quantity),
+                                jac,
+                                is_leaf=_is_quantity)
+        example_args = dyn_args[0] if isinstance(argnums, int) else dyn_args
+        jac_tree = _tree_transpose(outer=example_args, inner=y, pytree_to_transpose=jac_tree)
+        if not has_aux:
+            return jac_tree
+        else:
+            return jac_tree, aux
+
+    return jacfun
+
+
+def _tree_transpose(
+    outer: Any,
+    inner: Any,
+    pytree_to_transpose: Any
+) -> Any:
+    outer_leaves, outer_treedef = jax.tree.flatten(outer, is_leaf=_is_quantity)
+    inner_leaves, inner_treedef = jax.tree.flatten(inner, is_leaf=_is_quantity)
+    outer_leaf_units = [get_unit(leaf) for leaf in outer_leaves]
+    inner_leaf_units = [get_unit(leaf) for leaf in inner_leaves]
+
+    # tree transpose
+    flat, treedef = jax.tree.flatten(pytree_to_transpose, is_leaf=_is_quantity)
+    inner_size = inner_treedef.num_leaves
+    outer_size = outer_treedef.num_leaves
+    if treedef.num_leaves != (inner_size * outer_size):
+        expected_treedef = outer_treedef.compose(inner_treedef)
+        raise TypeError(f"Mismatch\n{treedef}\n != \n{expected_treedef}")
+    iter_flat = iter(flat)
+
+    # unit-aware tree transpose
+    lol = [
+        [
+            maybe_decimal(
+                Quantity(
+                    get_magnitude(next(iter_flat)),
+                    unit=inner_leaf_units[j] / outer_leaf_units[i]
+                )
+            )
+            for j in range(inner_size)
+        ]
+        for i in range(outer_size)
+    ]
+    transposed_lol = zip(*lol)
+    subtrees = map(partial(jax.tree.unflatten, outer_treedef), transposed_lol)
+    return jax.tree.unflatten(inner_treedef, subtrees)
+
+
+def jacobian(
+    fun: Callable,
+    argnums: int | Sequence[int] = 0,
+    has_aux: bool = False,
+    holomorphic: bool = False,
+    allow_int: bool = False
+) -> Callable:
+    """
+    Alias of :func:`jacrev`.
+    """
+    return jacrev(
+        fun,
+        argnums=argnums,
+        has_aux=has_aux,
+        holomorphic=holomorphic,
+        allow_int=allow_int
+    )
+
+
+def jacfwd(
+    fun: Callable,
+    argnums: int | Sequence[int] = 0,
+    has_aux: bool = False,
+    holomorphic: bool = False
+) -> Callable:
+    """
+    Physical unit-aware version of `jax.jacfwd <https://jax.readthedocs.io/en/latest/_autosummary/jax.jacfwd.html>`_.
+
+    Args:
+        fun: Function whose Jacobian is to be computed.
+        argnums: Optional, integer or sequence of integers. Specifies which
+            positional argument(s) to differentiate with respect to (default ``0``).
+        has_aux: Optional, bool. Indicates whether ``fun`` returns a pair where the
+            first element is considered the output of the mathematical function to be
+            differentiated and the second element is auxiliary data. Default False.
+        holomorphic: Optional, bool. Indicates whether ``fun`` is promised to be holomorphic. Default False.
+
+    Returns:
+        A function that computes the Jacobian of ``fun`` through forward-mode automatic differentiation.
+    """
+    _check_callable(fun)
+    argnums = _ensure_index(argnums)
+
+    @wraps(fun)
+    def jacfun(*args, **kwargs):
+        f = linear_util.wrap_init(fun, kwargs)
+        f_partial, dyn_args = argnums_partial(f, argnums, args, require_static_args_hashable=False)
+        jax.tree.map(partial(_check_input_dtype_jacfwd, holomorphic), dyn_args)
+        if not has_aux:
+            pushfwd: Callable = partial(_jvp, f_partial, dyn_args)
+            y, jac = jax.vmap(pushfwd, out_axes=(None, -1))(_std_basis(dyn_args))
+        else:
+            pushfwd: Callable = partial(_jvp, f_partial, dyn_args, has_aux=True)
+            y, jac, aux = jax.vmap(pushfwd, out_axes=(None, -1, None))(_std_basis(dyn_args))
+        jax.tree.map(partial(_check_output_dtype_jacfwd, holomorphic), y)
+        example_args = dyn_args[0] if isinstance(argnums, int) else dyn_args
+        jac_tree = jax.tree.map(partial(_jacfwd_unravel, example_args, is_leaf=_is_quantity),
+                                jac,
+                                is_leaf=_is_quantity)
+        if not has_aux:
+            return jac_tree
+        else:
+            return jac_tree, aux
+
+    return jacfun
+
+
+def _std_basis(pytree):
+    leaves, _ = jax.tree.flatten(pytree)
+    ndim = sum(jax.util.safe_map(np.size, leaves))
+    dtype = jax.dtypes.result_type(*leaves)
+    flat_basis = jax.numpy.eye(ndim, dtype=dtype)
+    return _unravel_array_into_pytree(pytree, 1, flat_basis)
+
+
+def _jacfwd_unravel(input_pytree, arr, is_leaf=None):
+    """
+    Unravel an array into a PyTree with a given structure.
+
+    Args:
+        input_pytree: The pytree that provides the structure.
+        arr: The array to be unraveled.
+    """
+    axis = -1
+    leaves, treedef = jax.tree.flatten(input_pytree, is_leaf=is_leaf)
+    axis = axis % arr.ndim
+    shapes = [arr.shape[:axis] + np.shape(l) + arr.shape[axis + 1:] for l in leaves]
+    parts = _split(arr, np.cumsum(jax.util.safe_map(np.size, leaves[:-1])), axis)
+    reshaped_parts = [x.reshape(shape) for x, shape in zip(parts, shapes)]
+    unit_reshaped_parts = [
+        maybe_decimal(
+            Quantity(
+                get_magnitude(part),
+                unit=get_unit(part) / get_unit(leaf)
+            )
+        )
+        for part, leaf in zip(reshaped_parts, leaves)
+    ]
+    return jax.tree.unflatten(treedef, unit_reshaped_parts)
+
+
+def _jacrev_unravel(output_pytree, arr, is_leaf=None):
+    return _unravel_array_into_pytree(output_pytree, 0, arr, is_leaf=is_leaf)
+
+
+def _unravel_array_into_pytree(pytree, axis, arr, is_leaf=None):
+    """
+    Unravel an array into a PyTree with a given structure.
+
+    Args:
+        pytree: The pytree that provides the structure.
+        axis: The parameter axis is either -1, 0, or 1.  It controls the
+          resulting shapes.
+        arr: The array to be unraveled.
+    """
+    leaves, treedef = jax.tree.flatten(pytree, is_leaf=is_leaf)
+    axis = axis % arr.ndim
+    shapes = [arr.shape[:axis] + np.shape(l) + arr.shape[axis + 1:] for l in leaves]
+    parts = _split(arr, np.cumsum(jax.util.safe_map(np.size, leaves[:-1])), axis)
+    reshaped_parts = [x.reshape(shape) for x, shape in zip(parts, shapes)]
+    return jax.tree.unflatten(treedef, reshaped_parts)
+
+
+def _split(x, indices, axis):
+    if isinstance(x, np.ndarray):
+        return np.split(x, indices, axis)
+    elif isinstance(x, Quantity):
+        return x.split(indices, axis)
+    else:
+        return x._split(indices, axis)
+
+
+def _is_quantity(x):
+    return isinstance(x, Quantity)

--- a/brainunit/autograd/_jacobian_test.py
+++ b/brainunit/autograd/_jacobian_test.py
@@ -1,0 +1,171 @@
+# Copyright 2024 BDP Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+
+import brainstate as bst
+import jax.numpy as jnp
+import pytest
+
+import brainunit as u
+
+
+def test_jacrev_simple_function():
+    def simple_function(x):
+        return x ** 2
+
+    jac_fn = u.autograd.jacrev(simple_function)
+
+    x = jnp.array(3.0)
+    jac = jac_fn(x)
+    assert jnp.allclose(jac, jnp.array([6.0]))
+
+    x = jnp.array(3.0) * u.ms
+    jac = jac_fn(x)
+    assert u.math.allclose(jac, jnp.array([6.0]) * u.ms)
+
+
+def test_jacrev_function2():
+    def simple_function(x, y):
+        return x * y
+
+    jac_fn = u.autograd.jacrev(simple_function, argnums=(0, 1))
+
+    x = bst.random.rand(3) * u.ohm
+    y = bst.random.rand(3) * u.mA
+    jac = jac_fn(x, y)
+    assert u.math.allclose(
+        jac[0],
+        u.math.diag(y)
+    )
+    assert u.math.allclose(
+        jac[1],
+        u.math.diag(x)
+    )
+
+
+def test_jacrev_function3():
+    def simple_function(inputs):
+        o1 = inputs['x'] * inputs['y']
+        o2 = inputs['x'] * inputs['z']
+        r = {'o1': o1, 'o2': o2}
+        return r, r
+
+    jac_fn = u.autograd.jacrev(simple_function, has_aux=True)
+
+    x = bst.random.rand(3) * u.ohm
+    y = bst.random.rand(3) * u.mA
+    z = bst.random.rand(3) * u.siemens
+
+    inp = {'x': x, 'y': y, 'z': z}
+    jac, r = jac_fn(inp)
+
+    assert u.math.allclose(
+        jac['o1']['x'],
+        u.math.diag(y)
+    )
+    assert u.math.allclose(
+        jac['o1']['y'],
+        u.math.diag(x)
+    )
+    assert u.math.allclose(
+        jac['o1']['z'],
+        u.math.diag(u.math.zeros(3) * u.get_unit(r['o1']) / u.get_unit(inp['z']))
+    )
+
+    assert u.math.allclose(
+        jac['o2']['x'],
+        u.math.diag(z)
+    )
+    assert u.math.allclose(
+        jac['o2']['y'],
+        u.math.diag(u.math.zeros(3) * u.get_unit(r['o2']) / u.get_unit(inp['y']))
+    )
+    assert u.math.allclose(
+        jac['o2']['z'],
+        u.math.diag(x)
+    )
+
+
+
+
+
+def test_jacrev_with_aux():
+    def simple_function(x):
+        return x ** 2, x
+
+    jac_fn = u.autograd.jacrev(simple_function, has_aux=True)
+    x = jnp.array(3.0)
+    jac, aux = jac_fn(x)
+    assert jnp.allclose(jac, jnp.array([6.0]))
+    assert jnp.allclose(aux, jnp.array(3.0))
+
+    x = jnp.array(3.0) * u.ms
+    jac, aux = jac_fn(x)
+    assert u.math.allclose(jac, jnp.array([6.0]) * u.ms)
+    assert u.math.allclose(aux, jnp.array(3.0) * u.ms)
+
+
+def test_jacfwd_simple_function():
+    def simple_function(x):
+        return x ** 2
+
+    jac_fn = u.autograd.jacfwd(simple_function)
+    x = jnp.array(3.0)
+    jac = jac_fn(x)
+    assert jnp.allclose(jac, jnp.array([6.0]))
+
+    x = jnp.array(3.0) * u.ms
+    jac = jac_fn(x)
+    assert u.math.allclose(jac, jnp.array([6.0]) * u.ms)
+
+
+def test_jacfwd_function2():
+    def simple_function(x, y):
+        return x * y
+
+    jac_fn = u.autograd.jacfwd(simple_function, argnums=(0, 1))
+
+    x = bst.random.rand(3) * u.ohm
+    y = bst.random.rand(3) * u.mA
+    jac = jac_fn(x, y)
+    assert u.math.allclose(
+        jac[0],
+        u.math.diag(y)
+    )
+    assert u.math.allclose(
+        jac[1],
+        u.math.diag(x)
+    )
+
+
+def test_jacfwd_with_aux():
+    def simple_function(x):
+        return x ** 2, x
+
+    jac_fn = u.autograd.jacfwd(simple_function, has_aux=True)
+
+    x = jnp.array(3.0)
+    jac, aux = jac_fn(x)
+    assert jnp.allclose(jac, jnp.array([6.0]))
+    assert jnp.allclose(aux, jnp.array(3.0))
+
+    x = jnp.array(3.0) * u.ms
+    jac, aux = jac_fn(x)
+    assert u.math.allclose(jac, jnp.array([6.0]) * u.ms)
+    assert u.math.allclose(aux, jnp.array(3.0) * u.ms)
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/brainunit/autograd/_misc.py
+++ b/brainunit/autograd/_misc.py
@@ -1,0 +1,54 @@
+# Copyright 2024 BDP Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from __future__ import annotations
+
+import operator
+from typing import Any
+import inspect
+from functools import partial, wraps
+
+import jax
+
+
+def _ensure_index(x: Any) -> int | tuple[int, ...]:
+    """
+    Ensure x is either an index or a tuple of indices.
+    """
+    x = jax.core.concrete_or_error(None, x, "expected a static index or sequence of indices.")
+    try:
+        return operator.index(x)
+    except TypeError:
+        return tuple(map(operator.index, x))
+
+def _isgeneratorfunction(fun):
+    # re-implemented here because of https://bugs.python.org/issue33261
+    while inspect.ismethod(fun):
+        fun = fun.__func__
+    while isinstance(fun, partial):
+        fun = fun.func
+    return inspect.isfunction(fun) and bool(fun.__code__.co_flags & inspect.CO_GENERATOR)
+
+
+def _check_callable(fun):
+    # In Python 3.10+, the only thing stopping us from supporting staticmethods
+    # is that we can't take weak references to them, which the C++ JIT requires.
+    if isinstance(fun, staticmethod):
+        raise TypeError(f"staticmethod arguments are not supported, got {fun}")
+    if not callable(fun):
+        raise TypeError(f"Expected a callable value, got {fun}")
+    if _isgeneratorfunction(fun):
+        raise TypeError(f"Expected a function, got a generator function: {fun}")
+

--- a/brainunit/autograd/_value_and_grad.py
+++ b/brainunit/autograd/_value_and_grad.py
@@ -1,0 +1,161 @@
+# Copyright 2024 BDP Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from __future__ import annotations
+
+from functools import wraps
+from typing import (Any, Sequence, Callable)
+
+import jax
+
+from brainunit._base import get_mantissa, get_unit, Quantity, maybe_decimal
+from ._misc import _ensure_index, _check_callable
+
+__all__ = [
+    'value_and_grad',
+    'grad',
+]
+
+
+def value_and_grad(
+    fun: Callable,
+    argnums: int | Sequence[int] = 0,
+    has_aux: bool = False,
+    holomorphic: bool = False,
+    allow_int: bool = False,
+) -> Callable[..., tuple[Any, Any]]:
+    """
+    Physical unit-aware version of
+    `jax.value_and_grad <https://jax.readthedocs.io/en/latest/_autosummary/jax.value_and_grad.html>`_.
+
+    Example::
+
+       >>> import jax.numpy as jnp
+       >>> import brainunit as u
+       >>> def simple_function(x):
+       ...    return x ** 2
+       >>> value_and_grad_fn = u.autograd.value_and_grad(simple_function)
+       >>> value, grad = value_and_grad_fn(jnp.array(3.0) * u.ms)
+       >>> value
+       9.0 * ms ** 2
+       >>> grad
+       6.0 * ms
+
+    Args:
+        fun: A Python callable that computes a scalar loss given arguments.
+        argnums: Optional, an integer or a tuple of integers. The argument number(s) to differentiate with respect to.
+        has_aux: Optional, whether `fun` returns auxiliary data.
+        holomorphic: Optional, whether to use a holomorphic or real-valued differentiation.
+        allow_int: Optional, whether to allow differentiation through integer inputs.
+
+    Returns:
+        A function that computes the value and gradient of `fun` with respect to
+        the argument(s) indicated by `argnums`.
+    """
+
+    argnums = jax.core.concrete_or_error(_ensure_index, argnums)
+
+    def fun_return_unitless_loss(*args, **kwargs):
+        if has_aux:
+            loss, aux = fun(*args, **kwargs)
+        else:
+            loss = fun(*args, **kwargs)
+            aux = None
+        return get_mantissa(loss), (loss, aux)
+
+    fun_transformed = jax.value_and_grad(
+        fun_return_unitless_loss,
+        argnums=argnums,
+        has_aux=True,
+        holomorphic=holomorphic,
+        allow_int=allow_int,
+    )
+
+    @wraps(fun)
+    def value_and_grad_fun(*args, **kwargs):
+        # autograd as usual
+        ((_, (loss, auxiliary_data)), gradient) = fun_transformed(*args, **kwargs)
+
+        # gradient Quantity conversion
+        args_to_grad = jax.tree.map(lambda i: args[i], argnums)
+        loss_unit = get_unit(loss)
+        gradient = jax.tree.map(
+            lambda arg, grads: maybe_decimal(
+                Quantity(get_mantissa(grads), unit=loss_unit / get_unit(arg))
+            ),
+            args_to_grad,
+            gradient,
+            is_leaf=lambda x: isinstance(x, Quantity)
+        )
+
+        # return
+        if has_aux:
+            return (loss, auxiliary_data), gradient
+        else:
+            return loss, gradient
+
+    return value_and_grad_fun
+
+
+def grad(
+    fun: Callable,
+    argnums: int | Sequence[int] = 0,
+    has_aux: bool = False,
+    holomorphic: bool = False,
+    allow_int: bool = False,
+) -> Callable:
+    """
+    Physical unit-aware version of `jax.grad <https://jax.readthedocs.io/en/latest/_autosummary/jax.grad.html>`_.
+
+    Example::
+
+       >>> import jax.numpy as jnp
+       >>> import brainunit as u
+       >>> def simple_function(x):
+       ...    return x ** 2
+       >>> grad_fn = u.autograd.grad(simple_function)
+       >>> grad_fn(jnp.array(3.0) * u.ms)
+       6.0 * ms
+
+    Args:
+        fun: A Python callable that computes a scalar loss given arguments.
+        argnums: Optional, an integer or a tuple of integers. The argument number(s) to differentiate with respect to.
+        has_aux: Optional, whether `fun` returns auxiliary data.
+        holomorphic: Optional, whether to use a holomorphic or real-valued differentiation.
+        allow_int: Optional, whether to allow differentiation through integer inputs.
+
+    Returns:
+        A function that computes the gradient of `fun` with respect to
+        the argument(s) indicated by `argnums`.
+    """
+    value_and_grad_f = value_and_grad(
+        fun,
+        argnums,
+        has_aux=has_aux,
+        holomorphic=holomorphic,
+        allow_int=allow_int
+    )
+
+    @wraps(fun)
+    def grad_f(*args, **kwargs):
+        _, g = value_and_grad_f(*args, **kwargs)
+        return g
+
+    @wraps(fun)
+    def grad_f_aux(*args, **kwargs):
+        (_, aux), g = value_and_grad_f(*args, **kwargs)
+        return g, aux
+
+    return grad_f_aux if has_aux else grad_f

--- a/brainunit/autograd/_value_and_grad_test.py
+++ b/brainunit/autograd/_value_and_grad_test.py
@@ -1,0 +1,108 @@
+# Copyright 2024 BDP Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import os
+
+os.environ['JAX_TRACEBACK_FILTERING'] = 'off'
+
+import jax.numpy as jnp
+import pytest
+import brainunit as u
+
+
+def test_value_and_grad_simple():
+    def simple_function(x):
+        return x ** 2
+
+    for unit in [None, u.ms, u.mvolt]:
+        value_and_grad_fn = u.autograd.value_and_grad(simple_function)
+        if unit is None:
+            value, grad = value_and_grad_fn(jnp.array(3.0))
+            assert value == 9.0
+            assert grad == 6.0
+        else:
+            value, grad = value_and_grad_fn(jnp.array(3.0) * unit)
+            assert u.math.allclose(value, 9.0 * unit ** 2)
+            assert u.math.allclose(grad, 6.0 * unit)
+
+
+def test_value_and_grad_multiple_args():
+    def multi_arg_function(x, y):
+        return x * y
+
+    for ux, uy in ([u.ms, u.mV],
+                   [u.ms, u.UNITLESS],
+                   [u.UNITLESS, u.mV],
+                   [u.UNITLESS, u.UNITLESS]):
+        value_and_grad_fn = u.autograd.value_and_grad(multi_arg_function, argnums=(0, 1))
+        value, grad = value_and_grad_fn(jnp.array(3.0) * ux, jnp.array(4.0) * uy)
+        assert u.math.allclose(value, 12.0 * ux * uy)
+        assert u.math.allclose(grad[0], 4.0 * uy)
+        assert u.math.allclose(grad[1], 3.0 * ux)
+
+
+def test_value_and_grad_with_aux():
+    def function_with_aux(x):
+        return x ** 2, x * 3
+
+    for unit in [u.UNITLESS, u.mV, u.ms, u.siemens]:
+        value_and_grad_fn = u.autograd.value_and_grad(function_with_aux, has_aux=True)
+        (value, aux), grad = value_and_grad_fn(jnp.array(3.0) * unit)
+        assert u.math.allclose(value, 9.0 * unit ** 2)
+        assert u.math.allclose(aux, 9.0 * unit)
+        assert u.math.allclose(grad, 6.0 * unit)
+
+
+def test_grad_simple():
+    def simple_function(x):
+        return x ** 2
+
+    for unit in [None, u.ms, u.mvolt]:
+        grad_fn = u.autograd.grad(simple_function)
+        if unit is None:
+            grad = grad_fn(jnp.array(3.0))
+            assert grad == 6.0
+        else:
+            grad = grad_fn(jnp.array(3.0) * unit)
+            assert u.math.allclose(grad, 6.0 * unit)
+
+
+def test_grad_multiple_args():
+    def multi_arg_function(x, y):
+        return x * y
+
+    for ux, uy in ([u.ms, u.mV],
+                   [u.ms, u.UNITLESS],
+                   [u.UNITLESS, u.mV],
+                   [u.UNITLESS, u.UNITLESS]):
+        grad_fn = u.autograd.grad(multi_arg_function, argnums=(0, 1))
+        grad = grad_fn(jnp.array(3.0) * ux, jnp.array(4.0) * uy)
+        assert u.math.allclose(grad[0], 4.0 * uy)
+        assert u.math.allclose(grad[1], 3.0 * ux)
+
+
+def test_grad_with_aux():
+    def function_with_aux(x):
+        return x ** 2, x * 3
+
+    for unit in [u.UNITLESS, u.mV, u.ms, u.siemens]:
+        grad_fn = u.autograd.grad(function_with_aux, has_aux=True)
+        grad, aux = grad_fn(jnp.array(3.0) * unit)
+        assert u.math.allclose(aux, 9.0 * unit)
+        assert u.math.allclose(grad, 6.0 * unit)
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/brainunit/autograd/_vector_grad.py
+++ b/brainunit/autograd/_vector_grad.py
@@ -1,0 +1,78 @@
+# Copyright 2024 BDP Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from __future__ import annotations
+
+from functools import wraps
+from typing import Callable, Sequence
+
+import jax
+from jax import numpy as jnp
+from jax._src.api import _vjp
+from jax.api_util import argnums_partial
+from jax.extend import linear_util
+
+from brainunit._base import get_unit, maybe_decimal, Quantity, get_mantissa
+from ._misc import _check_callable
+
+__all__ = [
+    'vector_grad',
+]
+
+
+def vector_grad(
+    func: Callable,
+    argnums: int | Sequence[int] = 0,
+    return_value: bool = False,
+    has_aux: bool = False,
+    unit_aware: bool = True,
+):
+    """
+     Compute the gradient of a vector with respect to the input.
+     """
+    _check_callable(func)
+
+    @wraps(func)
+    def grad_fun(*args, **kwargs):
+        f = linear_util.wrap_init(func, kwargs)
+        f_partial, dyn_args = argnums_partial(f, argnums, args, require_static_args_hashable=False)
+        if has_aux:
+            y, vjp_fn, aux = _vjp(f_partial, *dyn_args, has_aux=True)
+        else:
+            y, vjp_fn = _vjp(f_partial, *dyn_args, has_aux=False)
+        leaves, tree = jax.tree.flatten(y)
+        if unit_aware:
+            assert len(leaves) == 1, 'The function must return a single array when unit_aware is True.'
+        tangents = jax.tree.unflatten(tree, [jnp.ones(l.shape, dtype=l.dtype) for l in leaves])
+        grads = vjp_fn(tangents)
+        if unit_aware:
+            args_to_grad = jax.tree.map(lambda i: args[i], argnums)
+            r_unit = get_unit(leaves[0])
+            grads = jax.tree.map(
+                lambda arg, grad: maybe_decimal(
+                    Quantity(get_mantissa(grad), unit=r_unit / get_unit(arg))
+                ),
+                args_to_grad,
+                grads,
+                is_leaf=lambda x: isinstance(x, Quantity)
+            )
+        if isinstance(argnums, int):
+            grads = grads[0]
+        if has_aux:
+            return (grads, y, aux) if return_value else (grads, aux)
+        else:
+            return (grads, y) if return_value else grads
+
+    return grad_fun

--- a/brainunit/autograd/_vector_grad_test.py
+++ b/brainunit/autograd/_vector_grad_test.py
@@ -1,0 +1,89 @@
+# Copyright 2024 BDP Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+
+import os
+
+os.environ['JAX_TRACEBACK_FILTERING'] = 'off'
+
+import jax.numpy as jnp
+import pytest
+import brainunit as u
+
+
+def test_vector_grad_simple():
+    def simple_function(x):
+        return x ** 2
+
+    for unit in [None, u.ms, u.mvolt]:
+        vector_grad_fn = u.autograd.vector_grad(simple_function)
+        if unit is None:
+            grad = vector_grad_fn(jnp.array([3.0, 4.0]))
+            assert jnp.allclose(grad, jnp.array([6.0, 8.0]))
+        else:
+            grad = vector_grad_fn(jnp.array([3.0, 4.0]) * unit)
+            assert u.math.allclose(grad, jnp.array([6.0, 8.0]) * unit)
+
+
+def test_vector_grad_multiple_args():
+    def multi_arg_function(x, y):
+        return x * y
+
+    for ux, uy in ([u.ms, u.mV],
+                   [u.ms, u.UNITLESS],
+                   [u.UNITLESS, u.mV],
+                   [u.UNITLESS, u.UNITLESS]):
+        vector_grad_fn = u.autograd.vector_grad(multi_arg_function, argnums=(0, 1))
+        grad = vector_grad_fn(jnp.array([3.0, 4.0]) * ux,
+                              jnp.array([5.0, 6.0]) * uy)
+        assert u.math.allclose(grad[0], jnp.array([5.0, 6.0]) * uy)
+        assert u.math.allclose(grad[1], jnp.array([3.0, 4.0]) * ux)
+
+
+def test_vector_grad_with_aux():
+    def function_with_aux(x):
+        return x ** 2, jnp.sum(x * 3)
+
+    for unit in [u.UNITLESS, u.mV, u.ms, u.siemens]:
+        vector_grad_fn = u.autograd.vector_grad(function_with_aux, has_aux=True)
+        (value, aux), grad = vector_grad_fn(jnp.array([3.0, 4.0]) * unit)
+        assert u.math.allclose(value, jnp.array(25.0) * unit ** 2)
+        assert u.math.allclose(aux, jnp.array(21.0) * unit)
+        assert u.math.allclose(grad, jnp.array([6.0, 8.0]) * unit)
+
+
+def test_vector_grad_holomorphic():
+    def holomorphic_function(x):
+        return jnp.sum(x ** 2)
+
+    for unit in [u.UNITLESS, u.mV, u.ms, u.siemens]:
+        vector_grad_fn = u.autograd.vector_grad(holomorphic_function, holomorphic=True)
+        grad = vector_grad_fn(jnp.array([3.0 + 4.0j, 1.0 + 2.0j]) * unit)
+        assert u.math.allclose(grad, jnp.array([2 * (3.0 + 4.0j), 2 * (1.0 + 2.0j)]) * unit)
+
+
+@pytest.mark.skip(reason="JAX does not support differentiation through integer inputs")
+def test_vector_grad_allow_int():
+    def int_function(x):
+        return jnp.sum(x ** 2)
+
+    for unit in [u.UNITLESS, u.mV, u.ms, u.siemens]:
+        vector_grad_fn = u.autograd.vector_grad(int_function, allow_int=True)
+        grad = vector_grad_fn(jnp.array([3, 4]) * unit)
+        assert u.math.allclose(grad, jnp.array([6, 8]) * unit)
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/docs/apis/brainunit.autograd.rst
+++ b/docs/apis/brainunit.autograd.rst
@@ -1,0 +1,43 @@
+``brainunit.autograd`` module
+=============================
+
+.. currentmodule:: brainunit.autograd
+.. automodule:: brainunit.autograd
+
+
+
+First Order Derivatives
+------------------------
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+    value_and_grad
+    grad
+    vector_grad
+
+
+Jacobin
+---------
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+    jacrev
+    jacfwd
+    jacobian
+
+
+Hessian
+---------
+
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+    hessian
+
+

--- a/docs/auto_generater.py
+++ b/docs/auto_generater.py
@@ -268,49 +268,50 @@ def _import(mod, klass=None, is_jax=False):
 def main():
   os.makedirs('apis/', exist_ok=True)
 
-  _write_module(module_name='brainunit.math._einops',
-                automodule='brainunit.math',
-                filename='apis/brainunit.math.einops.rst',
-                header='Einstein Operations',
-                template=True)
-
-  _write_module(module_name='brainunit.math._fun_array_creation',
-                automodule='brainunit.math',
-                filename='apis/brainunit.math.array-creation.rst',
-                header='Array Creation Functions',
-                template=True)
-
-  _write_module(module_name='brainunit.math._fun_accept_unitless',
-                automodule='brainunit.math',
-                filename='apis/brainunit.math.unitless.rst',
-                header='Functions that Accepting Unitless',
-                template=True)
-
-  _write_module(module_name='brainunit.math._fun_change_unit',
-                automodule='brainunit.math',
-                filename='apis/brainunit.math.change-unit.rst',
-                header='Functions that Changing Unit',
-                template=True)
-
-  _write_module(module_name='brainunit.math._fun_keep_unit',
-                automodule='brainunit.math',
-                filename='apis/brainunit.math.keep-unit.rst',
-                header='Functions that Keeping Unit',
-                template=True)
-
-  _write_module(module_name='brainunit.math._fun_remove_unit',
-                automodule='brainunit.math',
-                filename='apis/brainunit.math.remove-unit.rst',
-                header='Functions that Removing Unit',
-                template=True)
-
-  _write_module(module_name='brainunit.math._misc',
-                automodule='brainunit.math',
-                filename='apis/brainunit.math.misc.rst',
-                header='Other Functions',
-                template=True)
+  # _write_module(module_name='brainunit.math._einops',
+  #               automodule='brainunit.math',
+  #               filename='apis/brainunit.math.einops.rst',
+  #               header='Einstein Operations',
+  #               template=True)
+  #
+  # _write_module(module_name='brainunit.math._fun_array_creation',
+  #               automodule='brainunit.math',
+  #               filename='apis/brainunit.math.array-creation.rst',
+  #               header='Array Creation Functions',
+  #               template=True)
+  #
+  # _write_module(module_name='brainunit.math._fun_accept_unitless',
+  #               automodule='brainunit.math',
+  #               filename='apis/brainunit.math.unitless.rst',
+  #               header='Functions that Accepting Unitless',
+  #               template=True)
+  #
+  # _write_module(module_name='brainunit.math._fun_change_unit',
+  #               automodule='brainunit.math',
+  #               filename='apis/brainunit.math.change-unit.rst',
+  #               header='Functions that Changing Unit',
+  #               template=True)
+  #
+  # _write_module(module_name='brainunit.math._fun_keep_unit',
+  #               automodule='brainunit.math',
+  #               filename='apis/brainunit.math.keep-unit.rst',
+  #               header='Functions that Keeping Unit',
+  #               template=True)
+  #
+  # _write_module(module_name='brainunit.math._fun_remove_unit',
+  #               automodule='brainunit.math',
+  #               filename='apis/brainunit.math.remove-unit.rst',
+  #               header='Functions that Removing Unit',
+  #               template=True)
+  #
+  # _write_module(module_name='brainunit.math._misc',
+  #               automodule='brainunit.math',
+  #               filename='apis/brainunit.math.misc.rst',
+  #               header='Other Functions',
+  #               template=True)
 
   module_and_name = [
+    ('_activation', 'Activation Functions'),
     ('_alias', 'Unit Processing'),
     ('_einops', 'Einstein Operations'),
     ('_fun_accept_unitless', 'Functions that Accepting Unitless'),
@@ -324,6 +325,44 @@ def main():
   _write_submodules(module_name='brainunit.math',
                     filename='apis/brainunit.math.rst',
                     header='``brainunit.math`` module',
+                    submodule_names=[k[0] for k in module_and_name],
+                    section_names=[k[1] for k in module_and_name])
+
+  module_and_name = [
+    ('_linalg_change_unit', 'Functions that Changing Unit'),
+    ('_linalg_keep_unit', 'Functions that Keeping Unit'),
+  ]
+
+  _write_submodules(module_name='brainunit.linalg',
+                    filename='apis/brainunit.linalg.rst',
+                    header='``brainunit.linalg`` module',
+                    submodule_names=[k[0] for k in module_and_name],
+                    section_names=[k[1] for k in module_and_name])
+
+  module_and_name = [
+    ('_lax_accept_unitless', 'Functions that Accepting Unitless'),
+    ('_lax_array_creation', 'Array Creation Functions'),
+    ('_lax_change_unit', 'Functions that Changing Unit'),
+    ('_lax_keep_unit', 'Functions that Keeping Unit'),
+    ('_fun_remove_unit', 'Functions that Removing Unit'),
+    ('_lax_linalg', 'Linalg Functions'),
+    ('_misc', 'Other Functions'),
+  ]
+
+  _write_submodules(module_name='brainunit.lax',
+                    filename='apis/brainunit.lax.rst',
+                    header='``brainunit.lax`` module',
+                    submodule_names=[k[0] for k in module_and_name],
+                    section_names=[k[1] for k in module_and_name])
+
+  module_and_name = [
+    ('_linalg_change_unit', 'Functions that Changing Unit'),
+    ('_linalg_keep_unit', 'Functions that Keeping Unit'),
+  ]
+
+  _write_submodules(module_name='brainunit.autograd',
+                    filename='apis/brainunit.autograd.rst',
+                    header='``brainunit.autograd`` module',
                     submodule_names=[k[0] for k in module_and_name],
                     section_names=[k[1] for k in module_and_name])
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -187,7 +187,10 @@ We are building the `brain dynamics programming ecosystem <https://ecosystem-for
 
    apis/changelog.md
    apis/brainunit.rst
+   apis/brainunit.autograd.rst
    apis/brainunit.math.rst
+   apis/brainunit.linalg.rst
+   apis/brainunit.lax.rst
 
 
 


### PR DESCRIPTION
This pull request introduces the `autograd` module to the `brainunit` package, which includes functionality for automatic differentiation. The key changes involve adding new files for the `autograd` module, updating the `__init__.py` file to include the new module, and modifying existing methods for better compatibility.

### New `autograd` module:

* [`brainunit/autograd/__init__.py`](diffhunk://#diff-fcfb47283f17364d52368a27f0cc8126c66736df635ded9b67f247b7c2b46f2aR1-R30): Added the `autograd` module with functions for automatic differentiation, such as `value_and_grad`, `grad`, `vector_grad`, `jacobian`, `jacrev`, `jacfwd`, and `hessian`.
* [`brainunit/autograd/_hessian.py`](diffhunk://#diff-eac0e8cf925cdc4f7da0408c8dd69cbaf3b8a68e94ef0b883a12e3b758b1e62fR1-R58): Implemented the `hessian` function, which computes the Hessian of a function with physical unit awareness.
* [`brainunit/autograd/_jacobian.py`](diffhunk://#diff-6bb63bbe1dbc675dc6b49cc714fdc2c7a2ca51f37f3cb39b054488233a604a5bR1-R262): Implemented `jacrev`, `jacfwd`, and `jacobian` functions for computing Jacobians with physical unit awareness.

### Updates to existing files:

* [`brainunit/__init__.py`](diffhunk://#diff-3a761c6195ec8c8c5d803159623e15bbc65324db5a4ecf797afd0193da93c189R22): Imported the new `autograd` module and updated the `__all__` list to include `autograd`. [[1]](diffhunk://#diff-3a761c6195ec8c8c5d803159623e15bbc65324db5a4ecf797afd0193da93c189R22) [[2]](diffhunk://#diff-3a761c6195ec8c8c5d803159623e15bbc65324db5a4ecf797afd0193da93c189L33-R34)
* [`brainunit/_base.py`](diffhunk://#diff-68f3b161fe7a5ee956cf1363f0ef9df0fda8ce903c36894fadc791ab363e9c57L3209-R3209): Modified the `reshape` method signature to accept a single `shape` argument instead of variadic arguments.

### New tests:

* [`brainunit/autograd/_hessian_test.py`](diffhunk://#diff-6dfd3b88c52dd85096285f8f1aec6764d35633ed7477d92f660a4f84ab2fe69bR1-R121): Added unit tests for the `hessian` function to verify its correctness with scalar, vector, and dictionary functions.
* [`brainunit/autograd/_jacobian_test.py`](diffhunk://#diff-7f3727540ada0a8ca79c33befff476f108441c23c5fbc6fec9e8386f5526c99fR1-R171): Added unit tests for `jacrev` and `jacfwd` functions to ensure they handle various cases correctly, including auxiliary outputs and multiple arguments.