### PR TITLE
fix docs

### DIFF
--- a/docs/apis/brainunit.autograd.rst
+++ b/docs/apis/brainunit.autograd.rst
@@ -1,43 +1,6 @@
 ``brainunit.autograd`` module
 =============================
 
-.. currentmodule:: brainunit.autograd
-.. automodule:: brainunit.autograd
-
-
-
-First Order Derivatives
-------------------------
-
-.. autosummary::
-   :toctree: generated/
-   :nosignatures:
-
-    value_and_grad
-    grad
-    vector_grad
-
-
-Jacobin
----------
-
-.. autosummary::
-   :toctree: generated/
-   :nosignatures:
-
-    jacrev
-    jacfwd
-    jacobian
-
-
-Hessian
----------
-
-
-.. autosummary::
-   :toctree: generated/
-   :nosignatures:
-
-    hessian
-
+.. currentmodule:: brainunit.autograd 
+.. automodule:: brainunit.autograd 
 

--- a/docs/auto_generater.py
+++ b/docs/auto_generater.py
@@ -344,7 +344,7 @@ def main():
     ('_lax_array_creation', 'Array Creation Functions'),
     ('_lax_change_unit', 'Functions that Changing Unit'),
     ('_lax_keep_unit', 'Functions that Keeping Unit'),
-    ('_fun_remove_unit', 'Functions that Removing Unit'),
+    ('_lax_remove_unit', 'Functions that Removing Unit'),
     ('_lax_linalg', 'Linalg Functions'),
     ('_misc', 'Other Functions'),
   ]
@@ -352,17 +352,6 @@ def main():
   _write_submodules(module_name='brainunit.lax',
                     filename='apis/brainunit.lax.rst',
                     header='``brainunit.lax`` module',
-                    submodule_names=[k[0] for k in module_and_name],
-                    section_names=[k[1] for k in module_and_name])
-
-  module_and_name = [
-    ('_linalg_change_unit', 'Functions that Changing Unit'),
-    ('_linalg_keep_unit', 'Functions that Keeping Unit'),
-  ]
-
-  _write_submodules(module_name='brainunit.autograd',
-                    filename='apis/brainunit.autograd.rst',
-                    header='``brainunit.autograd`` module',
                     submodule_names=[k[0] for k in module_and_name],
                     section_names=[k[1] for k in module_and_name])
 


### PR DESCRIPTION
This pull request includes several changes to the documentation and auto-generation script for the `brainunit.autograd` module. The most important changes involve removing outdated sections from the documentation and updating the auto-generation script to reflect these changes.

Documentation updates:

* [`docs/apis/brainunit.autograd.rst`](diffhunk://#diff-3b956fb27f20408d95ae11040975603ac3d8a6ad91533d54c71a361793ea763fL7-L43): Removed sections related to First Order Derivatives, Jacobian, and Hessian from the documentation.

Auto-generation script updates:

* [`docs/auto_generater.py`](diffhunk://#diff-8185226506b79495f81d2193ae6cb66e8df6d6d43c58b3b49d04930cebcb175aL347-R347): Updated the `module_and_name` list to rename `_fun_remove_unit` to `_lax_remove_unit`.
* [`docs/auto_generater.py`](diffhunk://#diff-8185226506b79495f81d2193ae6cb66e8df6d6d43c58b3b49d04930cebcb175aL358-L368): Removed the redundant `module_and_name` list and the corresponding `_write_submodules` call for `brainunit.autograd`.