### PR TITLE
fix `vector_grad` bugs

### DIFF
--- a/brainunit/autograd/_vector_grad_test.py
+++ b/brainunit/autograd/_vector_grad_test.py
@@ -39,6 +39,21 @@ def test_vector_grad_simple():
             assert u.math.allclose(grad, jnp.array([6.0, 8.0]) * unit)
 
 
+def test_vector_grad_simple2():
+    def simple_function(x):
+        return x ** 3
+
+    x = jnp.array([3.0, 4.0])
+    for unit in [None, u.ms, u.mvolt]:
+        vector_grad_fn = u.autograd.vector_grad(simple_function)
+        if unit is None:
+            grad = vector_grad_fn(x)
+            assert jnp.allclose(grad, 3 * x ** 2)
+        else:
+            grad = vector_grad_fn(x * unit)
+            assert u.math.allclose(grad, 3 * (x * unit) ** 2)
+
+
 def test_vector_grad_multiple_args():
     def multi_arg_function(x, y):
         return x * y


### PR DESCRIPTION
This pull request includes changes to the `brainunit/autograd/_vector_grad.py` and `brainunit/autograd/_vector_grad_test.py` files to improve the gradient computation and add new test cases. The most important changes are the modification of the gradient function to handle integer `argnums` correctly and the addition of a new test case for the vector gradient function.

Improvements to gradient computation:

* [`brainunit/autograd/_vector_grad.py`](diffhunk://#diff-17e38b7b1f5fdec379563862d2eef0b191a30b90640f91da74bb8f06953c90ecR60-R64): Modified the `grad_fun` function to handle integer `argnums` correctly by moving the check and adjustment of `grads` to an earlier point in the function. [[1]](diffhunk://#diff-17e38b7b1f5fdec379563862d2eef0b191a30b90640f91da74bb8f06953c90ecR60-R64) [[2]](diffhunk://#diff-17e38b7b1f5fdec379563862d2eef0b191a30b90640f91da74bb8f06953c90ecL71-L72)

Enhancements to test coverage:

* [`brainunit/autograd/_vector_grad_test.py`](diffhunk://#diff-06b038eb2e3a61bdb0de22d54f66d4639cc52f5f6163fa2e096c5448d6fdedbaR42-R56): Added a new test case `test_vector_grad_simple2` to verify the correctness of the vector gradient function with different units.