### PR TITLE
[linalg] Implement more methods of linalg module

### DIFF
--- a/brainunit/_base.py
+++ b/brainunit/_base.py
@@ -2409,7 +2409,7 @@ class Quantity:
     @property
     def T(self) -> 'Quantity':
         return Quantity(jnp.asarray(self.mantissa).T, unit=self.unit)
-    
+
     @property
     def mT(self) -> 'Quantity':
         return Quantity(jnp.asarray(self.mantissa).mT, unit=self.unit)

--- a/brainunit/_base.py
+++ b/brainunit/_base.py
@@ -2409,6 +2409,10 @@ class Quantity:
     @property
     def T(self) -> 'Quantity':
         return Quantity(jnp.asarray(self.mantissa).T, unit=self.unit)
+    
+    @property
+    def mT(self) -> 'Quantity':
+        return Quantity(jnp.asarray(self.mantissa).mT, unit=self.unit)
 
     @property
     def isreal(self) -> jax.Array:

--- a/brainunit/lax/_lax_linalg.py
+++ b/brainunit/lax/_lax_linalg.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from typing import Union, Callable, Any
+from typing import Union, Callable, Any, Tuple, List
 
 import jax
-from jax import lax
+from jax import lax, Array
 
 from brainunit.lax._lax_change_unit import unit_change
+from .. import Quantity
 from .._base import Quantity, maybe_decimal, fail_for_unit_mismatch
 from .._misc import set_module_as
 from ..math._fun_change_unit import _fun_change_unit_unary
@@ -65,7 +66,7 @@ def eig(
     x: Union[Quantity, jax.typing.ArrayLike],
     compute_left_eigenvectors: bool = True,
     compute_right_eigenvectors: bool = True
-) -> tuple[Quantity, jax.Array, jax.Array] | list[jax.Array] | tuple[Quantity, jax.Array] | Quantity:
+) -> tuple[Array | Quantity, Array, Array] | list[Array] | tuple[Array | Quantity, Array] | tuple[Array | Quantity]:
     """Eigendecomposition of a general matrix.
 
     Nonsymmetric eigendecomposition is at present only implemented on CPU.
@@ -87,31 +88,37 @@ def eig(
     """
     if compute_left_eigenvectors and compute_right_eigenvectors:
         if isinstance(x, Quantity):
-            w, vl, vr = lax.linalg.eig(x.mantissa, compute_left_eigenvectors=True, compute_right_eigenvectors=True)
+            w, vl, vr = lax.linalg.eig(x.mantissa, compute_left_eigenvectors=compute_left_eigenvectors,
+                                       compute_right_eigenvectors=compute_right_eigenvectors)
             return maybe_decimal(Quantity(w, unit=x.unit)), vl, vr
         else:
-            return lax.linalg.eig(x, compute_left_eigenvectors=True, compute_right_eigenvectors=True)
+            return lax.linalg.eig(x, compute_left_eigenvectors=compute_left_eigenvectors,
+                                  compute_right_eigenvectors=compute_right_eigenvectors)
     elif compute_left_eigenvectors:
         if isinstance(x, Quantity):
-            w, vl = lax.linalg.eig(x.mantissa, compute_left_eigenvectors=True, compute_right_eigenvectors=False)
+            w, vl = lax.linalg.eig(x.mantissa, compute_left_eigenvectors=compute_left_eigenvectors,
+                                   compute_right_eigenvectors=compute_right_eigenvectors)
             return maybe_decimal(Quantity(w, unit=x.unit)), vl
         else:
-            return lax.linalg.eig(x, compute_left_eigenvectors, compute_left_eigenvectors=True,
-                                  compute_right_eigenvectors=False)
+            return lax.linalg.eig(x, compute_left_eigenvectors=compute_left_eigenvectors,
+                                  compute_right_eigenvectors=compute_right_eigenvectors)
 
     elif compute_right_eigenvectors:
         if isinstance(x, Quantity):
-            w, vr = lax.linalg.eig(x.mantissa, compute_left_eigenvectors=False, compute_right_eigenvectors=True)
+            w, vr = lax.linalg.eig(x.mantissa, compute_left_eigenvectors=compute_left_eigenvectors,
+                                   compute_right_eigenvectors=compute_right_eigenvectors)
             return maybe_decimal(Quantity(w, unit=x.unit)), vr
         else:
-            return lax.linalg.eig(x, compute_right_eigenvectors, compute_left_eigenvectors=False,
-                                  compute_right_eigenvectors=True)
+            return lax.linalg.eig(x, compute_left_eigenvectors=compute_left_eigenvectors,
+                                  compute_right_eigenvectors=compute_right_eigenvectors)
     else:
         if isinstance(x, Quantity):
-            w = lax.linalg.eig(x.mantissa, compute_left_eigenvectors=False, compute_right_eigenvectors=False)
-            return maybe_decimal(Quantity(w, unit=x.unit))
+            w = lax.linalg.eig(x.mantissa, compute_left_eigenvectors=compute_left_eigenvectors,
+                               compute_right_eigenvectors=compute_right_eigenvectors)
+            return (maybe_decimal(Quantity(w, unit=x.unit)),)
         else:
-            return lax.linalg.eig(x, compute_left_eigenvectors=False, compute_right_eigenvectors=False)
+            return lax.linalg.eig(x, compute_left_eigenvectors=compute_left_eigenvectors,
+                                  compute_right_eigenvectors=compute_right_eigenvectors)
 
 
 @set_module_as('brainunit.lax')
@@ -344,7 +351,12 @@ def schur(
 @set_module_as('brainunit.lax')
 def svd(
     x: Union[Quantity, jax.typing.ArrayLike],
-) -> tuple[jax.Array, Quantity | jax.Array, jax.Array]:
+    *,
+    full_matrices: bool = True,
+    compute_uv: bool = True,
+    subset_by_index: tuple[int, int] | None = None,
+    algorithm: jax.lax.linalg.SvdAlgorithm | None = None,
+) -> Union[Quantity, jax.typing.ArrayLike] | tuple[jax.Array, Quantity | jax.Array, jax.Array]:
     """Singular value decomposition.
 
     Returns the singular values if compute_uv is False, otherwise returns a triple
@@ -352,10 +364,17 @@ def svd(
     the right singular vectors.
     """
     if isinstance(x, Quantity):
-        u, s, vh = lax.linalg.svd(x.mantissa)
-        return u, maybe_decimal(Quantity(s, unit=x.unit)), vh
+        if compute_uv:
+            u, s, vh = lax.linalg.svd(x.mantissa, full_matrices=full_matrices, compute_uv=compute_uv,
+                                      subset_by_index=subset_by_index, algorithm=algorithm)
+            return u, maybe_decimal(Quantity(s, unit=x.unit)), vh
+        else:
+            s = lax.linalg.svd(x.mantissa, full_matrices=full_matrices, compute_uv=compute_uv,
+                               subset_by_index=subset_by_index, algorithm=algorithm)
+            return maybe_decimal(Quantity(s, unit=x.unit))
     else:
-        return lax.linalg.svd(x)
+        return lax.linalg.svd(x, full_matrices=full_matrices, compute_uv=compute_uv,
+                              subset_by_index=subset_by_index, algorithm=algorithm)
 
 
 @set_module_as('brainunit.lax')

--- a/brainunit/lax/_lax_linalg.py
+++ b/brainunit/lax/_lax_linalg.py
@@ -6,7 +6,6 @@ import jax
 from jax import lax, Array
 
 from brainunit.lax._lax_change_unit import unit_change
-from .. import Quantity
 from .._base import Quantity, maybe_decimal, fail_for_unit_mismatch
 from .._misc import set_module_as
 from ..math._fun_change_unit import _fun_change_unit_unary

--- a/brainunit/linalg/_linalg_change_unit.py
+++ b/brainunit/linalg/_linalg_change_unit.py
@@ -20,7 +20,7 @@ from typing import Union
 import jax
 import jax.numpy as jnp
 
-from .. import Quantity, maybe_decimal, UNITLESS
+from .._base import Quantity, maybe_decimal, UNITLESS
 from .._misc import set_module_as
 from ..math._fun_change_unit import (
     dot, multi_dot, vdot, vecdot, inner,

--- a/brainunit/linalg/_linalg_change_unit.py
+++ b/brainunit/linalg/_linalg_change_unit.py
@@ -15,14 +15,382 @@
 
 from __future__ import annotations
 
+from typing import Union
+
+import jax
+import jax.numpy as jnp
+
+from .. import Quantity, maybe_decimal, UNITLESS
+from .._misc import set_module_as
 from ..math._fun_change_unit import (
     dot, multi_dot, vdot, vecdot, inner,
     outer, kron, matmul, tensordot,
-    matrix_power, det
+    matrix_power, det, cross, unit_change, _fun_change_unit_unary, _fun_change_unit_binary
 )
 
 __all__ = [
+    # Matrix and vector products
     'dot', 'multi_dot', 'vdot', 'vecdot',
-    'inner', 'outer', 'kron', 'matmul',
+    'inner', 'kron', 'matmul',
     'tensordot', 'matrix_power', 'det',
+    'cross',
+
+    # Decompositions
+    'cholesky', 'outer',
+
+    # Norms and other numbers
+    'det',
+
+    # Solving equations and inverting matrices
+    'solve', 'tensorsolve', 'lstsq',
+    'inv', 'pinv', 'tensorinv',
 ]
+
+
+@unit_change(lambda x: x ** 0.5)
+@set_module_as('brainunit.linalg')
+def cholesky(
+    a: Union[jax.typing.ArrayLike, Quantity],
+    *,
+    upper: bool = False
+) -> Union[Quantity, jax.Array]:
+    """Compute the Cholesky decomposition of a matrix.
+
+    JAX implementation of :func:`numpy.linalg.cholesky`.
+
+    The Cholesky decomposition of a matrix `A` is:
+
+    .. math::
+
+        A = U^HU
+
+    or
+
+    .. math::
+
+        A = LL^H
+
+    where `U` is an upper-triangular matrix and `L` is a lower-triangular matrix, and
+    :math:`X^H` is the Hermitian transpose of `X`.
+
+    Args:
+        a: input array, representing a (batched) positive-definite hermitian matrix.
+            Must have shape ``(..., N, N)``.
+        upper: if True, compute the upper Cholesky decomposition `L`. if False
+            (default), compute the lower Cholesky decomposition `U`.
+
+    Returns:
+        array of shape ``(..., N, N)`` representing the Cholesky decomposition
+        of the input. If the input is not Hermitian positive-definite, The result
+        will contain NaN entries.
+
+    Examples:
+        A small real Hermitian positive-definite matrix:
+
+        >>> x = jnp.array([[2., 1.],
+        ...                [1., 2.]])
+
+        Lower Cholesky factorization:
+
+        >>> brainunit.linalg.cholesky(x)
+        Array([[1.4142135 , 0.        ],
+               [0.70710677, 1.2247449 ]], dtype=float32)
+
+        Upper Cholesky factorization:
+
+        >>> brainunit.linalg.cholesky(x, upper=True)
+        Array([[1.4142135 , 0.70710677],
+               [0.        , 1.2247449 ]], dtype=float32)
+
+        Reconstructing ``x`` from its factorization:
+
+        >>> L = brainunit.linalg.cholesky(x)
+        >>> jnp.allclose(x, L @ L.T)
+        Array(True, dtype=bool)
+    """
+    return _fun_change_unit_unary(jnp.linalg.cholesky,
+                                  lambda u: u ** 0.5,
+                                  a,
+                                  upper=upper)
+
+
+@unit_change(lambda x, y: y / x)
+@set_module_as('brainunit.linalg')
+def solve(
+    a: Union[jax.typing.ArrayLike, Quantity],
+    b: Union[jax.typing.ArrayLike, Quantity],
+) -> Union[jax.typing.ArrayLike, Quantity]:
+    """Solve a linear system of equations
+
+    JAX implementation of :func:`numpy.linalg.solve`.
+
+    This solves a (batched) linear system of equations ``a @ x = b``
+    for ``x`` given ``a`` and ``b``.
+
+    Args:
+        a: array of shape ``(..., N, N)``.
+        b: array of shape ``(N,)`` (for 1-dimensional right-hand-side) or
+            ``(..., N, M)`` (for batched 2-dimensional right-hand-side).
+
+    Returns:
+        An array containing the result of the linear solve. The result has shape ``(..., N)``
+        if ``b`` is of shape ``(N,)``, and has shape ``(..., N, M)`` otherwise.
+
+    Examples:
+        A simple 3x3 linear system:
+
+        >>> A = jnp.array([[1., 2., 3.],
+        ...                [2., 4., 2.],
+        ...                [3., 2., 1.]])
+        >>> b = jnp.array([14., 16., 10.])
+        >>> x = brainunit.linalg.solve(A, b)
+        >>> x
+        Array([1., 2., 3.], dtype=float32)
+
+        Confirming that the result solves the system:
+
+        >>> jnp.allclose(A @ x, b)
+        Array(True, dtype=bool)
+    """
+    return _fun_change_unit_binary(jnp.linalg.solve,
+                                   lambda a, b: b / a,
+                                   a,
+                                   b)
+
+
+@unit_change(lambda x, y: y / x)
+@set_module_as('brainunit.linalg')
+def tensorsolve(
+    a: Union[jax.typing.ArrayLike, Quantity],
+    b: Union[jax.typing.ArrayLike, Quantity],
+    axes: tuple[int, ...] | None = None
+) -> Union[jax.typing.ArrayLike, Quantity]:
+    """Solve the tensor equation a x = b for x.
+
+    JAX implementation of :func:`numpy.linalg.tensorsolve`.
+
+    Args:
+        a: input array. After reordering via ``axes`` (see below), shape must be
+          ``(*b.shape, *x.shape)``.
+        b: right-hand-side array.
+        axes: optional tuple specifying axes of ``a`` that should be moved to the end
+
+    Returns:
+        array x such that after reordering of axes of ``a``, ``tensordot(a, x, x.ndim)``
+        is equivalent to ``b``.
+
+    Examples:
+        >>> key1, key2 = jax.random.split(jax.random.key(8675309))
+        >>> a = jax.random.normal(key1, shape=(2, 2, 4))
+        >>> b = jax.random.normal(key2, shape=(2, 2))
+        >>> x = brainunit.linalg.tensorsolve(a, b)
+        >>> x.shape
+        (4,)
+
+        Now show that ``x`` can be used to reconstruct ``b`` using
+        :func:`~jax.numpy.linalg.tensordot`:
+
+        >>> b_reconstructed = brainunit.linalg.tensordot(a, x, axes=x.ndim)
+        >>> jnp.allclose(b, b_reconstructed)
+        Array(True, dtype=bool)
+    """
+    return _fun_change_unit_binary(jnp.linalg.tensorsolve,
+                                   lambda a, b: b / a,
+                                   a,
+                                   b,
+                                   axes=axes)
+
+
+@unit_change(lambda x, y: y / x)
+@set_module_as('brainunit.linalg')
+def lstsq(
+    a: Union[jax.typing.ArrayLike, Quantity],
+    b: Union[jax.typing.ArrayLike, Quantity],
+    rcond: float | None = None,
+    *,
+    numpy_resid: bool = False
+) -> tuple[Union[jax.typing.ArrayLike, Quantity], jax.Array, jax.Array, jax.Array]:
+    """
+    Return the least-squares solution to a linear equation.
+
+    JAX implementation of :func:`numpy.linalg.lstsq`.
+
+    Args:
+        a: array of shape ``(M, N)`` representing the coefficient matrix.
+        b: array of shape ``(M,)`` or ``(M, K)`` representing the right-hand side.
+        rcond: Cut-off ratio for small singular values. Singular values smaller than
+            ``rcond * largest_singular_value`` are treated as zero. If None (default),
+            the optimal value will be used to reduce floating point errors.
+        numpy_resid: If True, compute and return residuals in the same way as NumPy's
+            `linalg.lstsq`. This is necessary if you want to precisely replicate NumPy's
+            behavior. If False (default), a more efficient method is used to compute residuals.
+
+    Returns:
+        Tuple of arrays ``(x, resid, rank, s)`` where
+
+        - ``x`` is a shape ``(N,)`` or ``(N, K)`` array containing the least-squares solution.
+        - ``resid`` is the sum of squared residual of shape ``()`` or ``(K,)``.
+        - ``rank`` is the rank of the matrix ``a``.
+        - ``s`` is the singular values of the matrix ``a``.
+
+    Examples:
+        >>> a = jnp.array([[1, 2],
+        ...                [3, 4]])
+        >>> b = jnp.array([5, 6])
+        >>> x, _, _, _ = brainunit.linalg.lstsq(a, b)
+        >>> with jnp.printoptions(precision=3):
+        ...   print(x)
+        [-4.   4.5]
+    """
+    if isinstance(a, Quantity) and isinstance(b, Quantity):
+        r = jnp.linalg.lstsq(a.mantissa, b.mantissa, rcond=rcond, numpy_resid=numpy_resid)
+        return maybe_decimal(Quantity(r[0], unit=b.unit / a.unit)), r[1], r[2], r[3]
+    elif isinstance(a, Quantity):
+        r = jnp.linalg.lstsq(a.mantissa, b, rcond=rcond, numpy_resid=numpy_resid)
+        return maybe_decimal(Quantity(r[0], unit=UNITLESS / a.unit)), r[1], r[2], r[3]
+    elif isinstance(b, Quantity):
+        r = jnp.linalg.lstsq(a, b.mantissa, rcond=rcond, numpy_resid=numpy_resid)
+        return maybe_decimal(Quantity(r[0], unit=b.unit)), r[1], r[2], r[3]
+    else:
+        return jnp.linalg.lstsq(a, b, rcond=rcond, numpy_resid=numpy_resid)
+
+
+@unit_change(lambda u: u ** -1)
+@set_module_as('brainunit.linalg')
+def inv(
+    a: Union[jax.typing.ArrayLike, Quantity],
+) -> Union[jax.typing.ArrayLike, Quantity]:
+    """Return the inverse of a square matrix
+
+    JAX implementation of :func:`numpy.linalg.inv`.
+
+    Args:
+        a: array of shape ``(..., N, N)`` specifying square array(s) to be inverted.
+
+    Returns:
+        Array of shape ``(..., N, N)`` containing the inverse of the input.
+
+    Notes:
+        In most cases, explicitly computing the inverse of a matrix is ill-advised. For
+        example, to compute ``x = inv(A) @ b``, it is more performant and numerically
+        precise to use a direct solve, such as :func:`jax.scipy.linalg.solve`.
+
+    Examples:
+        Compute the inverse of a 3x3 matrix
+
+        >>> a = jnp.array([[1., 2., 3.],
+        ...                [2., 4., 2.],
+        ...                [3., 2., 1.]])
+        >>> a_inv = brainunit.linalg.inv(a)
+        >>> a_inv  # doctest: +SKIP
+        Array([[ 0.        , -0.25      ,  0.5       ],
+               [-0.25      ,  0.5       , -0.25000003],
+               [ 0.5       , -0.25      ,  0.        ]], dtype=float32)
+
+        Check that multiplying with the inverse gives the identity:
+
+        >>> jnp.allclose(a @ a_inv, jnp.eye(3), atol=1E-5)
+        Array(True, dtype=bool)
+
+        Multiply the inverse by a vector ``b``, to find a solution to ``a @ x = b``
+
+        >>> b = jnp.array([1., 4., 2.])
+        >>> a_inv @ b
+        Array([ 0.  ,  1.25, -0.5 ], dtype=float32)
+
+        Note, however, that explicitly computing the inverse in such a case can lead
+        to poor performance and loss of precision as the size of the problem grows.
+        Instead, you should use a direct solver like :func:`jax.numpy.linalg.solve`:
+
+        >>> brainunit.linalg.solve(a, b)
+         Array([ 0.  ,  1.25, -0.5 ], dtype=float32)
+    """
+    return _fun_change_unit_unary(jnp.linalg.inv,
+                                  lambda u: u ** -1,
+                                  a)
+
+
+@unit_change(lambda u: u ** -1)
+@set_module_as('brainunit.linalg')
+def pinv(
+    a: Union[jax.typing.ArrayLike, Quantity],
+    rtol: jax.typing.ArrayLike | None = None,
+    hermitian: bool = False,
+    *,
+    rcond: jax.typing.ArrayLike | None = None,
+) -> Union[jax.typing.ArrayLike, Quantity]:
+    """Compute the (Moore-Penrose) pseudo-inverse of a matrix.
+
+    JAX implementation of :func:`numpy.linalg.pinv`.
+
+    Args:
+        a: array of shape ``(..., M, N)`` containing matrices to pseudo-invert.
+        rtol: float or array_like of shape ``a.shape[:-2]``. Specifies the cutoff
+            for small singular values.of shape ``(...,)``.
+            Cutoff for small singular values; singular values smaller
+            ``rtol * largest_singular_value`` are treated as zero. The default is
+            determined based on the floating point precision of the dtype.
+        hermitian: if True, then the input is assumed to be Hermitian, and a more
+            efficient algorithm is used (default: False)
+        rcond: deprecated alias of the ``rtol`` argument. Will result in a
+            :class:`DeprecationWarning` if used.
+
+    Returns:
+        An array of shape ``(..., N, M)`` containing the pseudo-inverse of ``a``.
+
+    Examples:
+        >>> a = jnp.array([[1, 2],
+        ...                [3, 4],
+        ...                [5, 6]])
+        >>> a_pinv = brainunit.linalg.pinv(a)
+        >>> a_pinv  # doctest: +SKIP
+        Array([[-1.333332  , -0.33333257,  0.6666657 ],
+               [ 1.0833322 ,  0.33333272, -0.41666582]], dtype=float32)
+
+        The pseudo-inverse operates as a multiplicative inverse so long as the
+        output is not rank-deficient:
+
+        >>> jnp.allclose(a_pinv @ a, jnp.eye(2), atol=1E-4)
+        Array(True, dtype=bool)
+    """
+    return _fun_change_unit_unary(jnp.linalg.pinv,
+                                  lambda u: u ** -1,
+                                  a,
+                                  rtol=rtol,
+                                  hermitian=hermitian,
+                                  rcond=rcond)
+
+
+@unit_change(lambda u: u ** -1)
+@set_module_as('brainunit.linalg')
+def tensorinv(
+    a: Union[jax.typing.ArrayLike, Quantity],
+    ind: int = 2,
+) -> Union[jax.typing.ArrayLike, Quantity]:
+    """Compute the tensor inverse of an array.
+
+    JAX implementation of :func:`numpy.linalg.tensorinv`.
+
+    This computes the inverse of the :func:`~jax.numpy.linalg.tensordot`
+    operation with the same ``ind`` value.
+
+    Args:
+        a: array to be inverted. Must have ``prod(a.shape[:ind]) == prod(a.shape[ind:])``
+        ind: positive integer specifying the number of indices in the tensor product.
+
+    Returns:
+        array of shape ``(*a.shape[ind:], *a.shape[:ind])`` containing the
+        tensor inverse of ``a``.
+
+    Examples:
+        >>> key = jax.random.key(1337)
+        >>> x = jax.random.normal(key, shape=(2, 2, 4))
+        >>> xinv = brainunit.linalg.tensorinv(x, 2)
+        >>> xinv_x = brainunit.linalg.tensordot(xinv, x, axes=2)
+        >>> jnp.allclose(xinv_x, jnp.eye(4), atol=1E-4)
+        Array(True, dtype=bool)
+        """
+    return _fun_change_unit_unary(jnp.linalg.tensorinv,
+                                  lambda u: u ** -1,
+                                  a,
+                                  ind=ind)

--- a/brainunit/linalg/_linalg_keep_unit.py
+++ b/brainunit/linalg/_linalg_keep_unit.py
@@ -19,17 +19,28 @@ from typing import (Union)
 
 import jax
 import jax.numpy as jnp
+from jax import Array
 
-from .._base import Quantity
+from .._base import Quantity, maybe_decimal
 from .._misc import set_module_as
-from ..math._fun_keep_unit import _fun_keep_unit_unary
+from ..lax import _lax_linalg as lax_linalg
+from ..math._fun_keep_unit import (
+    _fun_keep_unit_unary, trace, diagonal
+)
 
 __all__ = [
-    'norm',
+    # Decompositions
+    'qr', 'svd', 'svdvals',
+    # Matrix eigenvalues
+    'eig', 'eigh', 'eigvals', 'eigvalsh',
+    # Norms and other numbers
+    'norm', 'matrix_norm', 'vector_norm',
+    'trace',
+    # Other matrix operations
+    'diagonal', 'matrix_transpose',
 ]
 
-
-@set_module_as('brainunit.math')
+@set_module_as('brainunit.linalg')
 def norm(
     x: Union[jax.typing.ArrayLike, Quantity],
     ord: int | str | None = None,
@@ -72,30 +83,396 @@ def norm(
     - ``ord=-2`` computes the smallest singular value
 
     Examples:
-    Vector norms:
+        Vector norms:
 
-    >>> x = jnp.array([3., 4., 12.])
-    >>> jnp.linalg.norm(x)
-    Array(13., dtype=float32)
-    >>> jnp.linalg.norm(x, ord=1)
-    Array(19., dtype=float32)
-    >>> jnp.linalg.norm(x, ord=0)
-    Array(3., dtype=float32)
+        >>> x = jnp.array([3., 4., 12.])
+        >>> jnp.linalg.norm(x)
+        Array(13., dtype=float32)
+        >>> jnp.linalg.norm(x, ord=1)
+        Array(19., dtype=float32)
+        >>> jnp.linalg.norm(x, ord=0)
+        Array(3., dtype=float32)
 
-    Matrix norms:
+        Matrix norms:
 
-    >>> x = jnp.array([[1., 2., 3.],
-    ...                [4., 5., 7.]])
-    >>> jnp.linalg.norm(x)  # Frobenius norm
-    Array(10.198039, dtype=float32)
-    >>> jnp.linalg.norm(x, ord='nuc')  # nuclear norm
-    Array(10.762535, dtype=float32)
-    >>> jnp.linalg.norm(x, ord=1)  # 1-norm
-    Array(10., dtype=float32)
+        >>> x = jnp.array([[1., 2., 3.],
+        ...                [4., 5., 7.]])
+        >>> jnp.linalg.norm(x)  # Frobenius norm
+        Array(10.198039, dtype=float32)
+        >>> jnp.linalg.norm(x, ord='nuc')  # nuclear norm
+        Array(10.762535, dtype=float32)
+        >>> jnp.linalg.norm(x, ord=1)  # 1-norm
+        Array(10., dtype=float32)
 
-    Batched vector norm:
+        Batched vector norm:
 
-    >>> jnp.linalg.norm(x, axis=1)
-    Array([3.7416575, 9.486833 ], dtype=float32)
+        >>> jnp.linalg.norm(x, axis=1)
+        Array([3.7416575, 9.486833 ], dtype=float32)
     """
     return _fun_keep_unit_unary(jnp.linalg.norm, x, ord=ord, axis=axis, keepdims=keepdims)
+
+
+@set_module_as('brainunit.linalg')
+def matrix_norm(
+    x: Union[jax.typing.ArrayLike, Quantity],
+    *,
+    keepdims: bool = False,
+    ord: str = 'fro'
+) -> Union[jax.Array, Quantity]:
+    """Compute the norm of a matrix or stack of matrices.
+
+    JAX implementation of :func:`numpy.linalg.matrix_norm`
+
+    Args:
+        x: array of shape ``(..., M, N)`` for which to take the norm.
+        keepdims: if True, keep the reduced dimensions in the output.
+        ord: A string or int specifying the type of norm; default is the Frobenius norm.
+            See :func:`numpy.linalg.norm` for details on available options.
+
+    Returns:
+        array containing the norm of ``x``. Has shape ``x.shape[:-2]`` if ``keepdims`` is
+        False, or shape ``(..., 1, 1)`` if ``keepdims`` is True.
+
+    Examples:
+        >>> x = jnp.array([[1, 2, 3],
+        ...                [4, 5, 6],
+        ...                [7, 8, 9]])
+        >>> brainunit.linalg.matrix_norm(x)
+        Array(16.881943, dtype=float32)
+    """
+    return _fun_keep_unit_unary(jnp.linalg.norm,
+                                x,
+                                keepdims=keepdims,
+                                ord=ord)
+
+
+@set_module_as('brainunit.linalg')
+def vector_norm(
+    x: Union[jax.typing.ArrayLike, Quantity],
+    *, axis: int | None = None,
+    keepdims: bool = False,
+    ord: int | str = 2
+) -> Union[jax.Array, Quantity]:
+    """Compute the vector norm of a vector or batch of vectors.
+
+    JAX implementation of :func:`numpy.linalg.vector_norm`.
+
+    Args:
+        x: N-dimensional array for which to take the norm.
+        axis: optional axis along which to compute the vector norm. If None (default)
+            then ``x`` is flattened and the norm is taken over all values.
+        keepdims: if True, keep the reduced dimensions in the output.
+        ord: A string or int specifying the type of norm; default is the 2-norm.
+            See :func:`numpy.linalg.norm` for details on available options.
+
+    Returns:
+        array containing the norm of ``x``.
+
+    Examples:
+        Norm of a single vector:
+
+        >>> x = jnp.array([1., 2., 3.])
+        >>> jnp.linalg.vector_norm(x)
+        Array(3.7416575, dtype=float32)
+
+        Norm of a batch of vectors:
+
+        >>> x = jnp.array([[1., 2., 3.],
+        ...                [4., 5., 7.]])
+        >>> jnp.linalg.vector_norm(x, axis=1)
+        Array([3.7416575, 9.486833 ], dtype=float32)
+    """
+    return _fun_keep_unit_unary(jnp.linalg.norm,
+                                x,
+                                axis=axis,
+                                keepdims=keepdims,
+                                ord=ord)
+
+
+@set_module_as('brainunit.linalg')
+def qr(
+    a: Union[Quantity, jax.typing.ArrayLike],
+    mode: str = "reduced"
+) -> Array | Quantity:
+    """Compute the QR decomposition of an array
+
+    JAX implementation of :func:`numpy.linalg.qr`.
+
+    The QR decomposition of a matrix `A` is given by
+
+    .. math::
+
+        A = QR
+
+    Where `Q` is a unitary matrix (i.e. :math:`Q^HQ=I`) and `R` is an upper-triangular
+    matrix.
+
+    Args:
+        a: array of shape (..., M, N)
+        mode: Computational mode. Supported values are:
+
+        - ``"reduced"`` (default): return `Q` of shape ``(..., M, K)`` and `R` of shape
+          ``(..., K, N)``, where ``K = min(M, N)``.
+        - ``"complete"``: return `Q` of shape ``(..., M, M)`` and `R` of shape ``(..., M, N)``.
+        - ``"raw"``: return lapack-internal representations of shape ``(..., M, N)`` and ``(..., K)``.
+        - ``"r"``: return `R` only.
+
+    Returns:
+        A tuple ``(Q, R)`` (if ``mode`` is not ``"r"``) otherwise an array ``R``,
+        where:
+
+        - ``Q`` is an orthogonal matrix of shape ``(..., M, K)`` (if ``mode`` is ``"reduced"``)
+          or ``(..., M, M)`` (if ``mode`` is ``"complete"``).
+        - ``R`` is an upper-triangular matrix of shape ``(..., M, N)`` (if ``mode`` is
+          ``"r"`` or ``"complete"``) or ``(..., K, N)`` (if ``mode`` is ``"reduced"``)
+
+        with ``K = min(M, N)``.
+
+    Examples:
+        Compute the QR decomposition of a matrix:
+
+        >>> a = jnp.array([[1., 2., 3., 4.],
+        ...                [5., 4., 2., 1.],
+        ...                [6., 3., 1., 5.]])
+        >>> Q, R = brainunit.linalg.qr(a)
+        >>> Q  # doctest: +SKIP
+        Array([[-0.12700021, -0.7581426 , -0.6396022 ],
+               [-0.63500065, -0.43322435,  0.63960224],
+               [-0.7620008 ,  0.48737738, -0.42640156]], dtype=float32)
+        >>> R  # doctest: +SKIP
+        Array([[-7.8740077, -5.080005 , -2.4130025, -4.953006 ],
+               [ 0.       , -1.7870499, -2.6534991, -1.028908 ],
+               [ 0.       ,  0.       , -1.0660033, -4.050814 ]], dtype=float32)
+
+        Check that ``Q`` is orthonormal:
+
+        >>> jnp.allclose(Q.T @ Q, jnp.eye(3), atol=1E-5)
+        Array(True, dtype=bool)
+
+        Reconstruct the input:
+
+        >>> jnp.allclose(Q @ R, a)
+        Array(True, dtype=bool)
+    """
+    if isinstance(a, Quantity):
+        result = jnp.linalg.qr(a.mantissa)
+    else:
+        result = jnp.linalg.qr(a)
+    try:
+        Q, R = result
+        return Q, maybe_decimal(Quantity(R, unit=a.unit))
+    except:
+        return maybe_decimal(Quantity(result, unit=a.unit))
+
+
+svd = lax_linalg.svd
+
+
+@set_module_as('brainunit.linalg')
+def svdvals(
+    x: Union[Quantity, jax.typing.ArrayLike],
+) -> Union[jax.Array, Quantity]:
+    """Compute the singular values of a matrix.
+
+    JAX implementation of :func:`numpy.linalg.svdvals`.
+
+    Args:
+        x: array of shape ``(..., M, N)`` for which singular values will be computed.
+
+    Returns:
+        array of singular values of shape ``(..., K)`` with ``K = min(M, N)``.
+
+    Examples:
+        >>> x = jnp.array([[1, 2, 3],
+        ...                [4, 5, 6]])
+        >>> brainunit.linalg.svdvals(x)
+        Array([9.508031 , 0.7728694], dtype=float32)
+    """
+    return svd(x, compute_uv=False)
+
+
+@set_module_as('brainunit.linalg')
+def eig(
+    a: Union[Quantity, jax.typing.ArrayLike],
+) -> tuple[Union[jax.Array, Quantity], Union[jax.Array, Quantity]]:
+    """
+    Compute the eigenvalues and eigenvectors of a square array.
+
+    JAX implementation of :func:`numpy.linalg.eig`.
+
+    Args:
+        a: array of shape ``(..., M, M)`` for which to compute the eigenvalues and vectors.
+
+    Returns:
+        A tuple ``(eigenvalues, eigenvectors)`` with
+
+        - ``eigenvalues``: an array of shape ``(..., M)`` containing the eigenvalues.
+        - ``eigenvectors``: an array of shape ``(..., M, M)``, where column ``v[:, i]`` is the
+          eigenvector corresponding to the eigenvalue ``w[i]``.
+
+    Examples:
+        >>> a = jnp.array([[1., 2.],
+        ...                [2., 1.]])
+        >>> w, v = brainunit.linalg.eig(a)
+        >>> with jax.numpy.printoptions(precision=4):
+        ...   w
+        Array([ 3.+0.j, -1.+0.j], dtype=complex64)
+        >>> v
+        Array([[ 0.70710677+0.j, -0.70710677+0.j],
+               [ 0.70710677+0.j,  0.70710677+0.j]], dtype=complex64)
+    """
+    return lax_linalg.eig(a, compute_left_eigenvectors=False)
+
+
+@set_module_as('brainunit.linalg')
+def eigh(
+    a: Union[Quantity, jax.typing.ArrayLike],
+    UPLO: str | None = None,
+    symmetrize_input: bool = True
+) -> tuple[Union[jax.Array, Quantity], Union[jax.Array, Quantity]]:
+    """
+    Compute the eigenvalues and eigenvectors of a Hermitian matrix.
+
+    JAX implementation of :func:`numpy.linalg.eigh`.
+
+    Args:
+        a: array of shape ``(..., M, M)``, containing the Hermitian (if complex)
+            or symmetric (if real) matrix.
+        UPLO: specifies whether the calculation is done with the lower triangular
+            part of ``a`` (``'L'``, default) or the upper triangular part (``'U'``).
+        symmetrize_input: if True (default) then input is symmetrized, which leads
+            to better behavior under automatic differentiation.
+
+    Returns:
+        A namedtuple ``(eigenvalues, eigenvectors)`` where
+
+        - ``eigenvalues``: an array of shape ``(..., M)`` containing the eigenvalues,
+            sorted in ascending order.
+        - ``eigenvectors``: an array of shape ``(..., M, M)``, where column ``v[:, i]`` is the
+            normalized eigenvector corresponding to the eigenvalue ``w[i]``.
+
+    Examples:
+        >>> a = jnp.array([[1, -2j],
+        ...                [2j, 1]])
+        >>> w, v = brainunit.linalg.eigh(a)
+        >>> w
+        Array([-1.,  3.], dtype=float32)
+        >>> with jnp.printoptions(precision=3):
+        ...   v
+        Array([[-0.707+0.j   , -0.707+0.j   ],
+               [ 0.   +0.707j,  0.   -0.707j]], dtype=complex64)
+    """
+    if UPLO is None or UPLO == "L":
+        lower = True
+    elif UPLO == "U":
+        lower = False
+    else:
+        msg = f"UPLO must be one of None, 'L', or 'U', got {UPLO}"
+        raise ValueError(msg)
+    return lax_linalg.eigh(a, lower=lower, symmetrize_input=symmetrize_input)
+
+
+@set_module_as('brainunit.linalg')
+def eigvals(
+    a: Union[Quantity, jax.typing.ArrayLike],
+) -> Union[jax.Array, Quantity]:
+    """
+    Compute the eigenvalues of a general matrix.
+
+    JAX implementation of :func:`numpy.linalg.eigvals`.
+
+    Args:
+        a: array of shape ``(..., M, M)`` for which to compute the eigenvalues.
+
+    Returns:
+        An array of shape ``(..., M)`` containing the eigenvalues.
+
+    Examples:
+        >>> a = jnp.array([[1., 2.],
+        ...                [2., 1.]])
+        >>> w = brainunit.linalg.eigvals(a)
+        >>> with jnp.printoptions(precision=2):
+        ...  w
+        Array([ 3.+0.j, -1.+0.j], dtype=complex64)
+    """
+    return eig(a, compute_left_eigenvectors=False,
+               compute_right_eigenvectors=False)[0]
+
+
+@set_module_as('brainunit.linalg')
+def eigvalsh(
+    a: Union[Quantity, jax.typing.ArrayLike],
+    UPLO: str = 'L',
+) -> Union[jax.Array, Quantity]:
+    """
+    Compute the eigenvalues of a Hermitian matrix.
+
+    JAX implementation of :func:`numpy.linalg.eigvalsh`.
+
+    Args:
+        a: array of shape ``(..., M, M)``, containing the Hermitian (if complex)
+            or symmetric (if real) matrix.
+        UPLO: specifies whether the calculation is done with the lower triangular
+            part of ``a`` (``'L'``, default) or the upper triangular part (``'U'``).
+
+    Returns:
+        An array of shape ``(..., M)`` containing the eigenvalues, sorted in
+        ascending order.
+
+    Examples:
+        >>> a = jnp.array([[1, -2j],
+        ...                [2j, 1]])
+        >>> w = brainunit.linalg.eigvalsh(a)
+        >>> w
+        Array([-1.,  3.], dtype=float32)
+    """
+    return eigh(a, UPLO=UPLO)[0]
+
+@set_module_as('brainunit.linalg')
+def matrix_transpose(
+    x: Union[Quantity, jax.typing.ArrayLike],
+) -> Union[Quantity, jax.typing.ArrayLike]:
+    """Transpose a matrix or stack of matrices.
+
+    JAX implementation of :func:`numpy.linalg.matrix_transpose`.
+
+    Args:
+        x: array of shape ``(..., M, N)``
+
+    Returns:
+        array of shape ``(..., N, M)`` containing the matrix transpose of ``x``.
+
+    Examples:
+        Transpose of a single matrix:
+
+        >>> x = jnp.array([[1, 2, 3],
+        ...                [4, 5, 6]])
+        >>> brainunit.linalg.matrix_transpose(x)
+        Array([[1, 4],
+               [2, 5],
+               [3, 6]], dtype=int32)
+
+        Transpose of a stack of matrices:
+
+        >>> x = jnp.array([[[1, 2],
+        ...                 [3, 4]],
+        ...                [[5, 6],
+        ...                 [7, 8]]])
+        >>> brainunit.linalg.matrix_transpose(x)
+        Array([[[1, 3],
+                [2, 4]],
+        <BLANKLINE>
+               [[5, 7],
+                [6, 8]]], dtype=int32)
+
+        For convenience, the same computation can be done via the
+        :attr:`~jax.Array.mT` property of JAX array objects:
+
+        >>> x.mT
+        Array([[[1, 3],
+                [2, 4]],
+        <BLANKLINE>
+               [[5, 7],
+                [6, 8]]], dtype=int32)
+    """
+    return _fun_keep_unit_unary(jnp.linalg.matrix_transpose, x)

--- a/brainunit/linalg/_linalg_remove_unit.py
+++ b/brainunit/linalg/_linalg_remove_unit.py
@@ -1,0 +1,155 @@
+# Copyright 2024 BDP Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from __future__ import annotations
+
+from typing import (Union, Optional)
+
+import jax
+import jax.numpy as jnp
+
+from .._base import Quantity
+from .._misc import set_module_as
+from ..math._fun_remove_unit import _fun_remove_unit_unary
+
+__all__ = [
+    # Norms and other numbers
+    'cond', 'matrix_rank', 'slogdet',
+]
+
+
+@set_module_as('brainunit.linalg')
+def cond(
+    x: Union[jax.typing.ArrayLike, Quantity],
+    p=None
+) -> jax.Array:
+    """Compute the condition number of a matrix.
+
+    JAX implementation of :func:`numpy.linalg.cond`.
+
+    The condition number is defined as ``norm(x, p) * norm(inv(x), p)``. For ``p = 2``
+    (the default), the condition number is the ratio of the largest to the smallest
+    singular value.
+
+    Args:
+        x: array of shape ``(..., M, N)`` for which to compute the condition number.
+        p: the order of the norm to use. One of ``{None, 1, -1, 2, -2, inf, -inf, 'fro'}``;
+            see :func:`jax.numpy.linalg.norm` for the meaning of these. The default is ``p = None``,
+            which is equivalent to ``p = 2``. If not in ``{None, 2, -2}`` then ``x`` must be square,
+            i.e. ``M = N``.
+
+    Returns:
+        array of shape ``x.shape[:-2]`` containing the condition number.
+
+    Examples:
+
+        Well-conditioned matrix:
+
+        >>> x = jnp.array([[1, 2],
+        ...                [2, 1]])
+        >>> brainunit.linalg.cond(x)
+        Array(3., dtype=float32)
+
+        Ill-conditioned matrix:
+
+        >>> x = jnp.array([[1, 2],
+        ...                [0, 0]])
+        >>> brainunit.linalg.cond(x)
+        Array(inf, dtype=float32)
+    """
+    return _fun_remove_unit_unary(jnp.linalg.cond, x, p=p)
+
+
+@set_module_as('brainunit.linalg')
+def matrix_rank(
+    M: Union[jax.typing.ArrayLike, Quantity],
+    rtol: Optional[Union[jax.typing.ArrayLike, Quantity]] = None,
+    *,
+    tol: jax.typing.ArrayLike | None = None
+) -> jax.Array:
+    """Compute the rank of a matrix.
+
+    JAX implementation of :func:`numpy.linalg.matrix_rank`.
+
+    The rank is calculated via the Singular Value Decomposition (SVD), and determined
+    by the number of singular values greater than the specified tolerance.
+
+    Args:
+        M: array of shape ``(..., N, K)`` whose rank is to be computed.
+        rtol: optional array of shape ``(...)`` specifying the tolerance. Singular values
+            smaller than `rtol * largest_singular_value` are considered to be zero. If
+            ``rtol`` is None (the default), a reasonable default is chosen based the
+            floating point precision of the input.
+        tol: deprecated alias of the ``rtol`` argument. Will result in a
+            :class:`DeprecationWarning` if used.
+
+    Returns:
+        array of shape ``a.shape[-2]`` giving the matrix rank.
+
+    Notes:
+    The rank calculation may be inaccurate for matrices with very small singular
+    values or those that are numerically ill-conditioned. Consider adjusting the
+    ``rtol`` parameter or using a more specialized rank computation method in such cases.
+
+    Examples:
+        >>> a = jnp.array([[1, 2],
+        ...                [3, 4]])
+        >>> brainunit.linalg.matrix_rank(a)
+        Array(2, dtype=int32)
+
+        >>> b = jnp.array([[1, 0],  # Rank-deficient matrix
+        ...                [0, 0]])
+        >>> brainunit.linalg.matrix_rank(b)
+        Array(1, dtype=int32)
+    """
+    return _fun_remove_unit_unary(jnp.linalg.matrix_rank, M, rtol=rtol, tol=tol)
+
+
+@set_module_as('brainunit.linalg')
+def slogdet(
+    a: Union[jax.typing.ArrayLike, Quantity],
+    *,
+    method: str | None = None
+) -> tuple[jax.Array, jax.Array]:
+    """
+    Compute the sign and (natural) logarithm of the determinant of an array.
+
+    JAX implementation of :func:`numpy.linalg.slogdet`.
+
+    Args:
+        a: array of shape ``(..., M, M)`` for which to compute the sign and log determinant.
+        method: the method to use for determinant computation. Options are
+
+        - ``'lu'`` (default): use the LU decomposition.
+        - ``'qr'``: use the QR decomposition.
+
+    Returns:
+        A tuple of arrays ``(sign, logabsdet)``, each of shape ``a.shape[:-2]``
+
+        - ``sign`` is the sign of the determinant.
+        - ``logabsdet`` is the natural log of the determinant's absolute value.
+
+    Examples:
+        >>> a = jnp.array([[1, 2],
+        ...                [3, 4]])
+        >>> sign, logabsdet = brainunit.linalg.slogdet(a)
+        >>> sign  # -1 indicates negative determinant
+        Array(-1., dtype=float32)
+        >>> jnp.exp(logabsdet)  # Absolute value of determinant
+        Array(2., dtype=float32)
+    """
+    if isinstance(a, Quantity):
+        return jnp.linalg.slogdet(a.mantissa, method=method)
+    return jnp.linalg.slogdet(a, method=method)

--- a/brainunit/math/_fun_change_unit.py
+++ b/brainunit/math/_fun_change_unit.py
@@ -1362,7 +1362,7 @@ def det(
     Examples:
     >>> a = jnp.array([[1, 2],
     ...                [3, 4]])
-    >>> jnp.linalg.det(a)
+    >>> brainunit.linalg.det(a)
     Array(-2., dtype=float32)
     """
     if isinstance(a, Quantity):


### PR DESCRIPTION
This pull request includes several updates to the `brainunit` package, focusing on expanding functionality and improving type annotations. The key changes include the addition of new methods for linear algebra operations, enhancements to existing methods, and improvements to type annotations.

### New Methods:
* [`brainunit/linalg/_linalg_change_unit.py`](diffhunk://#diff-bc03792416a9dbe2226a53eb13f3bd337bfa69bd32bac6a2411632c738f481c7R18-R396): Added new methods for linear algebra operations including `cholesky`, `solve`, `tensorsolve`, `lstsq`, `inv`, `pinv`, and `tensorinv`. These methods provide JAX implementations of common linear algebra functions with unit handling.

### Enhancements to Existing Methods:
* [`brainunit/lax/_lax_linalg.py`](diffhunk://#diff-7dff6fa3e8f43a5484b8e7cedf491425d3f71d4f5d234f1a7eb7d8e5f6081feaL68-R68): Updated the `eig` and `svd` methods to include additional parameters such as `compute_left_eigenvectors`, `compute_right_eigenvectors`, `full_matrices`, `compute_uv`, `subset_by_index`, and `algorithm` for more flexible and comprehensive linear algebra operations. [[1]](diffhunk://#diff-7dff6fa3e8f43a5484b8e7cedf491425d3f71d4f5d234f1a7eb7d8e5f6081feaL68-R68) [[2]](diffhunk://#diff-7dff6fa3e8f43a5484b8e7cedf491425d3f71d4f5d234f1a7eb7d8e5f6081feaL347-R376)

### Type Annotations:
* [`brainunit/lax/_lax_linalg.py`](diffhunk://#diff-7dff6fa3e8f43a5484b8e7cedf491425d3f71d4f5d234f1a7eb7d8e5f6081feaL3-R6): Improved type annotations for the `eig` method to better reflect the possible return types, enhancing code clarity and type safety.
* [`brainunit/linalg/_linalg_keep_unit.py`](diffhunk://#diff-05fd5511a57cf4b5ae28a4d2185a0f46087daa9be086ff1b3815b1cfa74f4de8R22-R43): Added type annotations for `Array` and updated the `__all__` list to include newly added functions for better module exports and type safety.

### New Property:
* [`brainunit/_base.py`](diffhunk://#diff-68f3b161fe7a5ee956cf1363f0ef9df0fda8ce903c36894fadc791ab363e9c57R2413-R2416): Introduced a new property `mT` in the `Quantity` class to return the transpose of the mantissa, providing additional functionality for matrix operations.