### PR TITLE
[feat] Add new decorator assign_units for unit processing on input and output for a function that does not support unit operations

### DIFF
--- a/brainunit/_base.py
+++ b/brainunit/_base.py
@@ -55,7 +55,7 @@ __all__ = [
     # functions for checking
     'check_dims',
     'check_units',
-    'handle_units',
+    'assign_units',
     'fail_for_dimension_mismatch',
     'fail_for_unit_mismatch',
     'assert_quantity',
@@ -4455,12 +4455,12 @@ def check_units(**au):
 
 
 @set_module_as('brainunit')
-def handle_units(**au):
+def assign_units(**au):
     """
     Decorator to transform units of arguments passed to a function
     """
 
-    def do_handle_units(f):
+    def do_assign_units(f):
         @wraps(f)
         def new_f(*args, **kwds):
             newkeyset = kwds.copy()
@@ -4530,7 +4530,7 @@ def handle_units(**au):
 
         return new_f
 
-    return do_handle_units
+    return do_assign_units
 
 def _check_unit(f, val, unit):
     unit = UNITLESS if unit is None else unit

--- a/brainunit/_base.py
+++ b/brainunit/_base.py
@@ -4468,7 +4468,7 @@ def handle_units(**au):
                     elif specific_unit == 1:
                         if isinstance(v, Quantity):
                             newkeyset[n] = v.to_decimal()
-                        elif isinstance(v, jax.typing.ArrayLike):
+                        elif isinstance(v, (jax.Array, np.ndarray, int, float, complex)):
                             newkeyset[n] = v
                         else:
                             specific_unit = jax.typing.ArrayLike
@@ -4502,7 +4502,7 @@ def handle_units(**au):
                 elif specific_unit == 1:
                     if isinstance(result, Quantity):
                         result = result.to_decimal()
-                    elif isinstance(result, jax.typing.ArrayLike):
+                    elif isinstance(result, (jax.Array, np.ndarray, int, float, complex)):
                         result = jnp.asarray(result)
                     else:
                         specific_unit = jax.typing.ArrayLike

--- a/brainunit/_base.py
+++ b/brainunit/_base.py
@@ -4492,6 +4492,12 @@ def handle_units(**au):
                     newkeyset[n] = v
 
             result = f(**newkeyset)
+            if isinstance(result, tuple):
+                assert isinstance(au["result"], tuple), "The return value of the function is a tuple, but the decorator expected a single unit."
+                result = tuple(
+                    Quantity(r, unit=au["result"][i]) if isinstance(au["result"][i], Unit) else r
+                    for i, r in enumerate(result)
+                )
             if "result" in au:
                 specific_unit = au["result"]
                 if specific_unit == bool:

--- a/brainunit/_base_test.py
+++ b/brainunit/_base_test.py
@@ -1337,9 +1337,9 @@ class TestHelperFunctions(unittest.TestCase):
         # Try incorrect units
         with pytest.raises(u.UnitMismatchError):
             a_function(5 * second, None)
-        with pytest.raises(u.UnitMismatchError):
+        with pytest.raises(TypeError):
             a_function(5, None)
-        with pytest.raises(u.UnitMismatchError):
+        with pytest.raises(TypeError):
             a_function(object(), None)
 
         @u.handle_units(result=second)

--- a/brainunit/_base_test.py
+++ b/brainunit/_base_test.py
@@ -1395,12 +1395,12 @@ class TestHelperFunctions(unittest.TestCase):
         with pytest.raises(u.UnitMismatchError):
             d_function2(2)
 
-    def test_handle_units(self):
+    def test_assign_units(self):
         """
-        Test the handle_units decorator
+        Test the assign_units decorator
         """
 
-        @u.handle_units(v=volt)
+        @u.assign_units(v=volt)
         def a_function(v, x):
             """
             v has to have units of volt, x can have any (or no) unit.
@@ -1421,7 +1421,7 @@ class TestHelperFunctions(unittest.TestCase):
         with pytest.raises(TypeError):
             a_function(object(), None)
 
-        @u.handle_units(result=second)
+        @u.assign_units(result=second)
         def b_function():
             """
             Return a value in seconds if return_second is True, otherwise return
@@ -1432,7 +1432,7 @@ class TestHelperFunctions(unittest.TestCase):
         # Should work (returns second)
         assert b_function() == 5 * second
 
-        @u.handle_units(a=bool, b=1, result=bool)
+        @u.assign_units(a=bool, b=1, result=bool)
         def c_function(a, b):
             if a:
                 return b > 0
@@ -1447,13 +1447,33 @@ class TestHelperFunctions(unittest.TestCase):
             c_function(1 * mV, 1)
 
         # Multiple results
-        @u.handle_units(result=(second, volt))
+        @u.assign_units(result=(second, volt))
         def d_function():
             return 5, 3
 
         # Should work (returns second)
         assert d_function()[0] == 5 * second
         assert d_function()[1] == 3 * volt
+
+        # Multiple results
+        @u.assign_units(result={'u': second, 'v': (volt, metre)})
+        def d_function2(true_result):
+            """
+            Return a value in seconds if return_second is True, otherwise return
+            a value in volt.
+            """
+            if true_result == 0:
+                return {'u': 5, 'v': (3, 2)}
+            elif true_result == 1:
+                return 3, 5
+            else:
+                return 3, 5
+
+        # Should work (returns dict)
+        d_function2(0)
+        # Should fail (returns tuple)
+        with pytest.raises(TypeError):
+            d_function2(1)
 
 
 

--- a/brainunit/_base_test.py
+++ b/brainunit/_base_test.py
@@ -1367,6 +1367,16 @@ class TestHelperFunctions(unittest.TestCase):
         with pytest.raises(TypeError):
             c_function(1 * mV, 1)
 
+        # Multiple results
+        @u.handle_units(result=(second, volt))
+        def d_function():
+            return 5, 3
+
+        # Should work (returns second)
+        assert d_function()[0] == 5 * second
+        assert d_function()[1] == 3 * volt
+
+
 
 def test_str_repr():
     """

--- a/brainunit/_base_test.py
+++ b/brainunit/_base_test.py
@@ -1427,7 +1427,7 @@ class TestHelperFunctions(unittest.TestCase):
             Return a value in seconds if return_second is True, otherwise return
             a value in volt.
             """
-            return 5 * second
+            return 5
 
         # Should work (returns second)
         assert b_function() == 5 * second


### PR DESCRIPTION
This pull request introduces a new decorator function `assign_units` in the `brainunit` module to handle unit transformations for function arguments and return values. It also includes tests for this new functionality. The most important changes include adding the `assign_units` function, updating the `_base.py` file to include the new decorator, and adding corresponding tests.

### New functionality for unit transformation:

* Added `assign_units` decorator function to transform units of arguments passed to a function. (`brainunit/_base.py`)

### Codebase updates:

* Included `assign_units` in the list of functions for checking units. (`brainunit/_base.py`)
* Added `_assign_unit` helper function to handle unit assignment within the `assign_units` decorator. (`brainunit/_base.py`)

### Testing:

* Added `test_assign_units` method to test various scenarios for the `assign_units` decorator, ensuring it correctly handles unit transformations and raises appropriate errors. (`brainunit/_base_test.py`)