### PR TITLE
[fft] Optimize `fftfreq` logic

### DIFF
--- a/brainunit/fft/_fft_change_unit.py
+++ b/brainunit/fft/_fft_change_unit.py
@@ -1104,10 +1104,12 @@ def fftfreq(
         if sys.version_info >= (3, 10):
             return Quantity(jnpfft.fftfreq(n, d.to_decimal(time_unit), dtype=dtype, device=device), unit=freq_unit)
         else:
+            # noinspection PyUnresolvedReferences
             return Quantity(jnpfft.fftfreq(n, d.to_decimal(time_unit), dtype=dtype), unit=freq_unit)
     if sys.version_info >= (3, 10):
         return jnpfft.fftfreq(n, d, dtype=dtype, device=device)
     else:
+        # noinspection PyUnresolvedReferences
         return jnpfft.fftfreq(n, d, dtype=dtype)
 
 
@@ -1156,8 +1158,10 @@ def rfftfreq(
         if sys.version_info >= (3, 10):
             return Quantity(jnpfft.rfftfreq(n, d.to_decimal(time_unit), dtype=dtype, device=device), unit=freq_unit)
         else:
+            # noinspection PyUnresolvedReferences
             return Quantity(jnpfft.rfftfreq(n, d.to_decimal(time_unit), dtype=dtype), unit=freq_unit)
     if sys.version_info >= (3, 10):
         return jnpfft.rfftfreq(n, d, dtype=dtype, device=device)
     else:
+        # noinspection PyUnresolvedReferences
         return jnpfft.rfftfreq(n, d, dtype=dtype)

--- a/brainunit/fft/_fft_change_unit.py
+++ b/brainunit/fft/_fft_change_unit.py
@@ -1094,20 +1094,20 @@ def fftfreq(
         time_scale = _find_closet_scale(d.unit.scale)
         try:
             time_unit, freq_unit = _time_freq_map[time_scale]
-        except:
+        except KeyError:
             time_unit = d.unit
             freq_unit_scale = -d.unit.scale
             freq_unit = Unit.create(get_or_create_dimension(s=-1),
                                     name=f'10^{freq_unit_scale} hertz',
                                     dispname=f'10^{freq_unit_scale} Hz',
                                     scale=freq_unit_scale,)
-        try:
+        if sys.version_info >= (3, 10):
             return Quantity(jnpfft.fftfreq(n, d.to_decimal(time_unit), dtype=dtype, device=device), unit=freq_unit)
-        except:
+        else:
             return Quantity(jnpfft.fftfreq(n, d.to_decimal(time_unit), dtype=dtype), unit=freq_unit)
-    try:
+    if sys.version_info >= (3, 10):
         return jnpfft.fftfreq(n, d, dtype=dtype, device=device)
-    except:
+    else:
         return jnpfft.fftfreq(n, d, dtype=dtype)
 
 
@@ -1146,18 +1146,18 @@ def rfftfreq(
         time_scale = _find_closet_scale(d.unit.scale)
         try:
             time_unit, freq_unit = _time_freq_map[time_scale]
-        except:
+        except KeyError:
             time_unit = d.unit
             freq_unit_scale = -d.unit.scale
             freq_unit = Unit.create(get_or_create_dimension(s=-1),
                                     name=f'10^{freq_unit_scale} hertz',
                                     dispname=f'10^{freq_unit_scale} Hz',
                                     scale=freq_unit_scale, )
-        try:
+        if sys.version_info >= (3, 10):
             return Quantity(jnpfft.rfftfreq(n, d.to_decimal(time_unit), dtype=dtype, device=device), unit=freq_unit)
-        except:
+        else:
             return Quantity(jnpfft.rfftfreq(n, d.to_decimal(time_unit), dtype=dtype), unit=freq_unit)
-    try:
+    if sys.version_info >= (3, 10):
         return jnpfft.rfftfreq(n, d, dtype=dtype, device=device)
-    except:
+    else:
         return jnpfft.rfftfreq(n, d, dtype=dtype)


### PR DESCRIPTION
This pull request includes changes to the `brainunit/fft/_fft_change_unit.py` file, specifically focusing on improving exception handling and compatibility with different Python versions. The most important changes include replacing generic exceptions with `KeyError` and adding version checks for Python 3.10 and above.

Improvements to exception handling:

* Replaced generic `except` statements with `except KeyError` in the `fftfreq` and `rfftfreq` functions. [[1]](diffhunk://#diff-8591ba3c62d6f16300a655a32b5e40463abfece77c33124b3167adfe897051e0L1097-R1112) [[2]](diffhunk://#diff-8591ba3c62d6f16300a655a32b5e40463abfece77c33124b3167adfe897051e0L1149-R1166)

Compatibility with Python versions:

* Added version checks for Python 3.10 and above to handle the `device` parameter in the `fftfreq` and `rfftfreq` functions. [[1]](diffhunk://#diff-8591ba3c62d6f16300a655a32b5e40463abfece77c33124b3167adfe897051e0L1097-R1112) [[2]](diffhunk://#diff-8591ba3c62d6f16300a655a32b5e40463abfece77c33124b3167adfe897051e0L1149-R1166)