### PR TITLE
add `compatible_with_equinox`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,13 +54,6 @@ docs/apis/generated
 docs/apis/math/generated
 docs/apis/integrators/generated
 
-develop/benchmark/COBA/brian2*
-develop/benchmark/COBA/annarchy*
-develop/benchmark/COBAHH/brian2*
-develop/benchmark/COBAHH/annarchy*
-develop/benchmark/CUBA/annarchy*
-develop/benchmark/CUBA/brian2*
-
 
 *~
 \#*\#

--- a/brainunit/_unit_constants.py
+++ b/brainunit/_unit_constants.py
@@ -15,7 +15,7 @@
 
 r"""
 A module providing some physical units as `Quantity` objects. Note that these
-units are not imported by wildcard imports (e.g. `from brian2 import *`), they
+units are not imported by wildcard imports, they
 have to be imported explicitly. You can use ``import ... as ...`` to import them
 with shorter names, e.g.::
 
@@ -24,7 +24,7 @@ with shorter names, e.g.::
 The available constants are:
 
 ==================== ================== ======================= ==================================================================
-Constant             Symbol(s)          Brian name              Value
+Constant             Symbol(s)          name                    Value
 ==================== ================== ======================= ==================================================================
 Avogadro constant    :math:`N_A, L`     ``avogadro_constant``   :math:`6.022140857\times 10^{23}\,\mathrm{mol}^{-1}`
 Boltzmann constant   :math:`k`          ``boltzmann_constant``  :math:`1.38064852\times 10^{-23}\,\mathrm{J}\,\mathrm{K}^{-1}`


### PR DESCRIPTION
This pull request includes several changes to the `brainunit` package, focusing on compatibility improvements, code cleanup, and documentation updates. The most important changes include adding a compatibility mode with Equinox, cleaning up redundant comments, and enhancing the documentation for the `Unit` class.

This feature enable the [diffrax](https://github.com/chaoming0625/diffrax) no longer need modified `equinox` and `optimisix`.
See https://github.com/chaoming0625/diffrax


### Compatibility improvements:
* Added a global variable `compat_with_equinox` and a function `compatible_with_equinox` to enable or disable compatibility with Equinox. Updated the `__pow__` method in the `Quantity` class to handle Equinox's internal `_omega` type. (`brainunit/_base.py`, [[1]](diffhunk://#diff-68f3b161fe7a5ee956cf1363f0ef9df0fda8ce903c36894fadc791ab363e9c57R73-R78) [[2]](diffhunk://#diff-68f3b161fe7a5ee956cf1363f0ef9df0fda8ce903c36894fadc791ab363e9c57R2939-R2946)

### Code cleanup:
* Removed redundant comments in the `fail_for_dimension_mismatch` and `fail_for_unit_mismatch` functions. (`brainunit/_base.py`, [[1]](diffhunk://#diff-68f3b161fe7a5ee956cf1363f0ef9df0fda8ce903c36894fadc791ab363e9c57L812-L813) [[2]](diffhunk://#diff-68f3b161fe7a5ee956cf1363f0ef9df0fda8ce903c36894fadc791ab363e9c57L880-L881)

### Documentation updates:
* Enhanced the `Unit` class documentation to include a mathematical representation of a unit. (`brainunit/_base.py`, [brainunit/_base.pyL1276-R1293](diffhunk://#diff-68f3b161fe7a5ee956cf1363f0ef9df0fda8ce903c36894fadc791ab363e9c57L1276-R1293))
* Corrected and clarified various comments and docstrings, including removing references to "Brian" and updating the list of available constants. (`brainunit/_base.py`, [[1]](diffhunk://#diff-68f3b161fe7a5ee956cf1363f0ef9df0fda8ce903c36894fadc791ab363e9c57L1340-R1349) [[2]](diffhunk://#diff-68f3b161fe7a5ee956cf1363f0ef9df0fda8ce903c36894fadc791ab363e9c57L1350-R1363); `brainunit/_unit_constants.py`, [[3]](diffhunk://#diff-9f81eaed397bf4834438dee224b1f037c0619563c78035f1a863bd2e8bf9024fL18-R18) [[4]](diffhunk://#diff-9f81eaed397bf4834438dee224b1f037c0619563c78035f1a863bd2e8bf9024fL27-R27)