### PR TITLE
support binary operation between two sparse matrix

### DIFF
--- a/brainunit/sparse/_coo.py
+++ b/brainunit/sparse/_coo.py
@@ -222,37 +222,63 @@ class COO(SparseMatrix):
         )
 
     def _binary_op(self, other, op):
+        if isinstance(other, COO):
+            if id(self.row) == id(other.row) and id(self.col) == id(other.col):
+                return COO(
+                    (op(self.data, other.data), self.row, self.col),
+                    shape=self.shape,
+                    rows_sorted=self._rows_sorted,
+                    cols_sorted=self._cols_sorted
+                )
         if isinstance(other, JAXSparse):
-            raise NotImplementedError("mul between two sparse objects.")
+            raise NotImplementedError(f"binary operation {op} between two sparse objects.")
+
         other = asarray(other)
         if other.size == 1:
             return COO(
                 (op(self.data, other), self.row, self.col),
-                shape=self.shape
+                shape=self.shape,
+                rows_sorted=self._rows_sorted,
+                cols_sorted=self._cols_sorted
             )
         elif other.ndim == 2 and other.shape == self.shape:
             other = other[self.row, self.col]
             return COO(
                 (op(self.data, other), self.row, self.col),
-                shape=self.shape
+                shape=self.shape,
+                rows_sorted=self._rows_sorted,
+                cols_sorted=self._cols_sorted
             )
         else:
             raise NotImplementedError(f"mul with object of shape {other.shape}")
 
     def _binary_rop(self, other, op):
+        if isinstance(other, COO):
+            if id(self.row) == id(other.row) and id(self.col) == id(other.col):
+                return COO(
+                    (op(other.data, self.data), self.row, self.col),
+                    shape=self.shape,
+                    rows_sorted=self._rows_sorted,
+                    cols_sorted=self._cols_sorted
+                )
         if isinstance(other, JAXSparse):
-            raise NotImplementedError("mul between two sparse objects.")
+            raise NotImplementedError(f"binary operation {op} between two sparse objects.")
+
         other = asarray(other)
         if other.size == 1:
             return COO(
                 (op(other, self.data), self.row, self.col),
-                shape=self.shape
+                shape=self.shape,
+                rows_sorted=self._rows_sorted,
+                cols_sorted=self._cols_sorted
             )
         elif other.ndim == 2 and other.shape == self.shape:
             other = other[self.row, self.col]
             return COO(
                 (op(other, self.data), self.row, self.col),
-                shape=self.shape
+                shape=self.shape,
+                rows_sorted=self._rows_sorted,
+                cols_sorted=self._cols_sorted
             )
         else:
             raise NotImplementedError(f"mul with object of shape {other.shape}")

--- a/brainunit/sparse/_coo_test.py
+++ b/brainunit/sparse/_coo_test.py
@@ -302,6 +302,9 @@ class TestCOO(unittest.TestCase):
 
             grads = jax.grad(f)(sp, xs)
 
+            sp = sp + grads * 1e-3
+            sp = sp + 1e-3 * grads
+
     def test_jit(self):
         @jax.jit
         def f(sp, x):

--- a/brainunit/sparse/_csr.py
+++ b/brainunit/sparse/_csr.py
@@ -120,8 +120,15 @@ class CSR(SparseMatrix):
         return CSR((self.data.__pos__(), self.indices, self.indptr), shape=self.shape)
 
     def _binary_op(self, other, op):
+        if isinstance(other, CSR):
+            if id(other.indices) == id(self.indices) and id(other.indptr) == id(self.indptr):
+                return CSR(
+                    (op(self.data, other.data), self.indices, self.indptr),
+                    shape=self.shape
+                )
         if isinstance(other, JAXSparse):
-            raise NotImplementedError("mul between two sparse objects.")
+            raise NotImplementedError(f"binary operation {op} between two sparse objects.")
+
         other = asarray(other)
         if other.size == 1:
             return CSR(
@@ -139,8 +146,15 @@ class CSR(SparseMatrix):
             raise NotImplementedError(f"mul with object of shape {other.shape}")
 
     def _binary_rop(self, other, op):
+        if isinstance(other, CSR):
+            if id(other.indices) == id(self.indices) and id(other.indptr) == id(self.indptr):
+                return CSR(
+                    (op(other.data, self.data), self.indices, self.indptr),
+                    shape=self.shape
+                )
         if isinstance(other, JAXSparse):
-            raise NotImplementedError("mul between two sparse objects.")
+            raise NotImplementedError(f"binary operation {op} between two sparse objects.")
+
         other = asarray(other)
         if other.size == 1:
             return CSR(
@@ -294,8 +308,15 @@ class CSC(SparseMatrix):
         return CSC((self.data.__pos__(), self.indices, self.indptr), shape=self.shape)
 
     def _binary_op(self, other, op):
+        if isinstance(other, CSC):
+            if id(other.indices) == id(self.indices) and id(other.indptr) == id(self.indptr):
+                return CSC(
+                    (op(self.data, other.data), self.indices, self.indptr),
+                    shape=self.shape
+                )
         if isinstance(other, JAXSparse):
-            raise NotImplementedError("mul between two sparse objects.")
+            raise NotImplementedError(f"binary operation {op} between two sparse objects.")
+
         other = asarray(other)
         if other.size == 1:
             return CSC(
@@ -313,8 +334,15 @@ class CSC(SparseMatrix):
             raise NotImplementedError(f"mul with object of shape {other.shape}")
 
     def _binary_rop(self, other, op):
+        if isinstance(other, CSC):
+            if id(other.indices) == id(self.indices) and id(other.indptr) == id(self.indptr):
+                return CSC(
+                    (op(other.data, self.data), self.indices, self.indptr),
+                    shape=self.shape
+                )
         if isinstance(other, JAXSparse):
-            raise NotImplementedError("mul between two sparse objects.")
+            raise NotImplementedError(f"binary operation {op} between two sparse objects.")
+
         other = asarray(other)
         if other.size == 1:
             return CSC(

--- a/brainunit/sparse/_csr_test.py
+++ b/brainunit/sparse/_csr_test.py
@@ -301,6 +301,9 @@ class TestCSR(unittest.TestCase):
 
             grads = jax.grad(f)(csr, xs)
 
+            csr = csr + grads * 1e-3
+            csr = csr + 1e-3 * grads
+
     def test_jit(self):
         @jax.jit
         def f(csr, x):
@@ -595,6 +598,9 @@ class TestCSC(unittest.TestCase):
             xs = bst.random.randn(20)
 
             grads = jax.grad(f)(csc, xs)
+
+            csc = csc + grads * 1e-3
+            csc = csc + 1e-3 * grads
 
     def test_jit(self):
 


### PR DESCRIPTION
This pull request includes several changes to the `brainunit/sparse` module, primarily focusing on enhancing binary operations and improving test cases for sparse matrix formats. The most important changes include adding support for binary operations between sparse matrices of the same format and updating test cases to include gradient-based updates.

Enhancements to binary operations:

* [`brainunit/sparse/_coo.py`](diffhunk://#diff-b5414a799ad9d0d474a7b9b31aa3f3feadc704750937519bebaa7f1a62788a6bR225-R281): Added support for binary operations between `COO` matrices with the same row and column indices. Updated error messages for unsupported operations to include the operation name.
* [`brainunit/sparse/_csr.py`](diffhunk://#diff-84124311b5e04fab22d0562c251d30837c6ea30e92815d6339885c10e16b45a3R123-R131): Added support for binary operations between `CSR` matrices with the same indices and indptr. Updated error messages for unsupported operations to include the operation name. [[1]](diffhunk://#diff-84124311b5e04fab22d0562c251d30837c6ea30e92815d6339885c10e16b45a3R123-R131) [[2]](diffhunk://#diff-84124311b5e04fab22d0562c251d30837c6ea30e92815d6339885c10e16b45a3R149-R157)
* [`brainunit/sparse/_csr.py`](diffhunk://#diff-84124311b5e04fab22d0562c251d30837c6ea30e92815d6339885c10e16b45a3R311-R319): Added support for binary operations between `CSC` matrices with the same indices and indptr. Updated error messages for unsupported operations to include the operation name. [[1]](diffhunk://#diff-84124311b5e04fab22d0562c251d30837c6ea30e92815d6339885c10e16b45a3R311-R319) [[2]](diffhunk://#diff-84124311b5e04fab22d0562c251d30837c6ea30e92815d6339885c10e16b45a3R337-R345)

Improvements to test cases:

* [`brainunit/sparse/_coo_test.py`](diffhunk://#diff-649301b5144e72f8e214154e835d676cf94d70812525b18b36b96b94f5143284R305-R307): Updated test cases to include gradient-based updates for `COO` matrices.
* [`brainunit/sparse/_csr_test.py`](diffhunk://#diff-c2d37301adf1341c055858f77df438e00bb74dbe57110efa95cce1ce867428a1R304-R306): Updated test cases to include gradient-based updates for `CSR` and `CSC` matrices. [[1]](diffhunk://#diff-c2d37301adf1341c055858f77df438e00bb74dbe57110efa95cce1ce867428a1R304-R306) [[2]](diffhunk://#diff-c2d37301adf1341c055858f77df438e00bb74dbe57110efa95cce1ce867428a1R602-R604)