### PR TITLE
Remove `automatically_register_units`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -225,3 +225,4 @@ cython_debug/
 /docs/apis/brainunit.linalg.rst
 /docs/apis/brainunit.math.rst
 /docs/apis/changelog.md
+/dist-hist/

--- a/.gitignore
+++ b/.gitignore
@@ -226,3 +226,4 @@ cython_debug/
 /docs/apis/brainunit.math.rst
 /docs/apis/changelog.md
 /dist-hist/
+/dist-hist/

--- a/brainunit/__init__.py
+++ b/brainunit/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-__version__ = "0.0.3"
+__version__ = "0.0.4"
 
 from . import _matplotlib_compat
 from . import autograd

--- a/brainunit/_base.py
+++ b/brainunit/_base.py
@@ -1760,9 +1760,15 @@ class Unit:
             return f'Unit({self.base}^{self.scale})'
         else:
             if self.factor == 1.:
-                return f'{self.base}^{self.scale} * {self.name}'
+                if self.scale == 0:
+                    return f'{self.name}'
+                else:
+                    return f'{self.base}^{self.scale} * {self.name}'
             else:
-                return f'{self.factor} * {self.base}^{self.scale} * {self.name}'
+                if self.scale == 0:
+                    return f'{self.factor} * {self.name}'
+                else:
+                    return f'{self.factor} * {self.base}^{self.scale} * {self.name}'
 
     def __str__(self) -> str:
         if self.is_fullname:
@@ -1771,9 +1777,15 @@ class Unit:
             return f'Unit({self.base}^{self.scale})'
         else:
             if self.factor == 1.:
-                return f'{self.base}^{self.scale} * {self.dispname}'
+                if self.scale == 0:
+                    return f'{self.dispname}'
+                else:
+                    return f'{self.base}^{self.scale} * {self.dispname}'
             else:
-                return f'{self.factor} * {self.base}^{self.scale} * {self.dispname}'
+                if self.scale == 0:
+                    return f'{self.factor} * {self.dispname}'
+                else:
+                    return f'{self.factor} * {self.base}^{self.scale} * {self.dispname}'
 
     def __mul__(self, other) -> 'Unit' | Quantity:
         # self * other

--- a/brainunit/_unit_common.py
+++ b/brainunit/_unit_common.py
@@ -2097,8 +2097,6 @@ __all__ = [
     ]
 
 
-Unit.automatically_register_units = False
-
 #### FUNDAMENTAL UNITS
 metre = Unit.create(get_or_create_dimension(m=1), "metre", "m")
 meter = Unit.create(get_or_create_dimension(m=1), "meter", "m")

--- a/brainunit/sparse/_csr.py
+++ b/brainunit/sparse/_csr.py
@@ -101,7 +101,7 @@ class CSR(SparseMatrix):
         assert data.shape == self.data.shape
         assert data.dtype == self.data.dtype
         assert get_unit(data) == get_unit(self.data)
-        return CSR((data, self.indices, self.indptr), shape=self.shape)
+        return self.__class__((data, self.indices, self.indptr), shape=self.shape)
 
     def todense(self):
         return csr_todense(self)

--- a/brainunit/sparse/_csr_test.py
+++ b/brainunit/sparse/_csr_test.py
@@ -52,6 +52,29 @@ class TestCSR(unittest.TestCase):
                 )
             )
 
+    def test_matvec_non_unit(self):
+        data = bst.random.rand(10, 20)
+        data = data * (data < 0.3)
+
+        csr = u.sparse.CSR.fromdense(data)
+
+        x = bst.random.random((10,))
+
+        self.assertTrue(
+            u.math.allclose(
+                x @ data,
+                x @ csr
+            )
+        )
+
+        x = bst.random.random((20,))
+        self.assertTrue(
+            u.math.allclose(
+                data @ x,
+                csr @ x
+            )
+        )
+
     def test_matmul(self):
         for ux, uy in [
             (u.ms, u.mV),

--- a/dev/units_template.py
+++ b/dev/units_template.py
@@ -25,7 +25,6 @@ from ._base import (Unit, get_or_create_dimension)
 
 {all}
 
-Unit.automatically_register_units = False
 
 #### FUNDAMENTAL UNITS
 metre = Unit.create(get_or_create_dimension(m=1), "metre", "m")


### PR DESCRIPTION
This pull request includes several changes to the `brainunit` package, focusing on version updates, string representation improvements, unit registration, and testing enhancements. The most important changes are summarized below:

Version update:
* Updated the version of the `brainunit` package from `0.0.3` to `0.0.4` in `brainunit/__init__.py`.

String representation improvements:
* Enhanced the `__repr__` and `__str__` methods in `brainunit/_base.py` to handle cases where `scale` is `0`, improving the readability of unit representations. [[1]](diffhunk://#diff-68f3b161fe7a5ee956cf1363f0ef9df0fda8ce903c36894fadc791ab363e9c57R1763-R1769) [[2]](diffhunk://#diff-68f3b161fe7a5ee956cf1363f0ef9df0fda8ce903c36894fadc791ab363e9c57R1780-R1786)

Unit registration:
* Removed the line that automatically registers units in `brainunit/_unit_common.py` and `dev/units_template.py` to prevent unintended unit registrations. [[1]](diffhunk://#diff-095849c8d9445e5c135c9bd3bd11501342aaf1ec910caeff856a1bdbf6596395L2100-L2101) [[2]](diffhunk://#diff-8b6abea9ec58a26973f042b80916ceff84de93139a8857a8bf092e3b788fbae1L28)

Class instantiation:
* Modified the `with_data` method in `brainunit/sparse/_csr.py` to use `self.__class__` for creating new instances, ensuring compatibility with subclasses.

Testing enhancements:
* Added a new test case `test_matvec_non_unit` in `brainunit/sparse/_csr_test.py` to verify the correctness of matrix-vector multiplication for non-unit data.