### PR TITLE
Old version compatibility

### DIFF
--- a/brainunit/__init__.py
+++ b/brainunit/__init__.py
@@ -32,14 +32,30 @@ from ._unit_common import __all__ as _common_all
 from ._unit_constants import *
 from ._unit_shortcuts import *
 from ._unit_shortcuts import __all__ as _std_units_all
-# from .constants import *
-# from .constants import __all__ as _constants_all
 
 __all__ = (
-    ['math', 'linalg', 'autograd', 'fft', 'constants', 'sparse'] +
+    [
+        'math',
+        'linalg',
+        'autograd',
+        'fft',
+        'constants',
+        'sparse'
+    ] +
     _common_all +
     _std_units_all +
     _base_all +
     _celsius_all
 )
 del _common_all, _std_units_all, _base_all, _celsius_all, _matplotlib_compat
+
+# old version compatibility
+avogadro_constant = constants.avogadro
+boltzmann_constant = constants.boltzmann
+electric_constant = constants.electric
+electron_mass = constants.electron_mass
+elementary_charge = constants.elementary_charge
+faraday_constant = constants.faraday
+gas_constant = constants.gas
+magnetic_constant = constants.magnetic
+molar_mass_constant = constants.molar_mass

--- a/brainunit/_unit_constants.py
+++ b/brainunit/_unit_constants.py
@@ -17,6 +17,18 @@ from ._base import Unit
 from ._unit_common import joule, kilogram, second, meter, radian, pascal, meter2, meter3, kelvin, watt, newton
 from .math import pi
 
+__all__ = [
+    "metric_ton", "grain", "lb", "pound", "slinch", "blob", "slug", "oz", "ounce", "stone", "long_ton", "short_ton",
+    "troy_ounce", "troy_pound", "carat", "atomic_mass", "u", "um_u", "degree", "arcmin", "arcminute", "arcsec",
+    "arcsecond", "minute", "hour", "day", "week", "month", "year", "julian_year", "inch", "foot", "yard", "mile",
+    "mil", "point", "pica", "survey_foot", "survey_mile", "nautical_mile", "fermi", "angstrom", "micron",
+    "astronomical_unit", "au", "light_year", "parsec", "atm", "atmosphere", "bar", "mmHg", "torr", "psi",
+    "hectare", "acre", "gallon", "gallon_US", "gallon_imp", "fluid_ounce", "fluid_ounce_US", "fluid_ounce_imp",
+    "bbl", "barrel", "speed_unit", "kmh", "mph", "mach", "speed_of_sound", "knot", "degree_Fahrenheit", "eV",
+    "electron_volt", "calorie", "calorie_th", "calorie_IT", "erg", "Btu", "Btu_IT", "Btu_th", "ton_TNT", "hp",
+    "horsepower", "dyn", "dyne", "lbf", "pound_force", "kgf", "kilogram_force", "IMF"
+]
+
 # ----- Mass -----
 metric_ton = Unit.create(kilogram.dim, name="metric ton", dispname="t", scale=kilogram.scale + 3)
 grain = Unit.create(kilogram.dim, name="grain", dispname="gr", scale=kilogram.scale - 5, factor=6.479891)

--- a/brainunit/constants.py
+++ b/brainunit/constants.py
@@ -51,28 +51,48 @@ from ._unit_common import (
     kilogram,
     meter,
     mole,
-    newton, radian, second, pascal, meter2, meter3, watt,
+    newton,
+    radian,
+    second,
+    meter2,
+    meter3,
+    watt,
 )
 from ._unit_constants import speed_unit
 
+__all__ = [
+    'arcmin', 'arcminute', 'arcsec', 'arcsecond', 'atomic_mass', 'au', 'astronomical_unit',
+    'angstrom', 'atm', 'atmosphere', 'avogadro', 'bar', 'blob', 'boltzmann', 'Btu', 'Btu_IT',
+    'Btu_th', 'carat', 'calorie', 'calorie_IT', 'calorie_th', 'day', 'degree', 'degree_Fahrenheit',
+    'dyn', 'dyne', 'eV', 'electron_mass', 'electric', 'electronvolt', 'elementary_charge', 'erg',
+    'faraday', 'fermi', 'fluid_ounce', 'fluid_ounce_US', 'fluid_ounce_imp', 'foot', 'gas', 'grain',
+    'gallon', 'gallon_US', 'gallon_imp', 'gram', 'hectare', 'hour', 'hp', 'horsepower', 'IMF',
+    'inch', 'julian_year', 'kelvin', 'kgf', 'kilogram_force', 'knot', 'lb', 'lbf', 'light_year',
+    'long_ton', 'mach', 'magnetic', 'meter', 'metric_ton', 'micron', 'mil', 'mile', 'minute',
+    'molar_mass', 'month', 'mph', 'nautical_mile', 'newton', 'ounce', 'oz', 'parsec', 'pica',
+    'point', 'pound', 'psi', 'radian', 'second', 'short_ton', 'slug', 'slinch', 'speed_unit',
+    'stone', 'survey_foot', 'survey_mile', 'torr', 'troy_ounce', 'troy_pound', 'ton_TNT', 'week',
+    'watt', 'year', 'zero_celsius'
+]
+
 #: Avogadro constant (http://physics.nist.gov/cgi-bin/cuu/Value?na)
-avogadro_constant = np.asarray(6.022140857e23) / mole
+avogadro = np.asarray(6.022140857e23) / mole
 #: Boltzmann constant (physics.nist.gov/cgi-bin/cuu/Value?k)
-boltzmann_constant = np.asarray(1.38064852e-23) * (joule / kelvin)
+boltzmann = np.asarray(1.38064852e-23) * (joule / kelvin)
 #: electric constant (http://physics.nist.gov/cgi-bin/cuu/Value?ep0)
-electric_constant = np.asarray(8.854187817e-12) * (farad / meter)
+electric = np.asarray(8.854187817e-12) * (farad / meter)
 #: Electron rest mass (physics.nist.gov/cgi-bin/cuu/Value?me)
 electron_mass = np.asarray(9.10938356e-31) * kilogram
 #: Elementary charge (physics.nist.gov/cgi-bin/cuu/Value?e)
 elementary_charge = np.asarray(1.6021766208e-19) * coulomb
 #: Faraday constant (http://physics.nist.gov/cgi-bin/cuu/Value?f)
-faraday_constant = np.asarray(96485.33289) * (coulomb / mole)
+faraday = np.asarray(96485.33289) * (coulomb / mole)
 #: gas constant (http://physics.nist.gov/cgi-bin/cuu/Value?r)
-gas_constant = np.asarray(8.3144598) * (joule / mole / kelvin)
+gas = np.asarray(8.3144598) * (joule / mole / kelvin)
 #: Magnetic constant (http://physics.nist.gov/cgi-bin/cuu/Value?mu0)
-magnetic_constant = np.asarray(4 * np.pi * 1e-7) * (newton / amp ** 2)
+magnetic = np.asarray(4 * np.pi * 1e-7) * (newton / amp ** 2)
 #: Molar mass constant (http://physics.nist.gov/cgi-bin/cuu/Value?mu)
-molar_mass_constant = np.asarray(1.) * (gram / mole)
+molar_mass = np.asarray(1.) * (gram / mole)
 #: zero degree Celsius
 zero_celsius = np.asarray(273.15) * kelvin
 

--- a/brainunit/constants_test.py
+++ b/brainunit/constants_test.py
@@ -47,36 +47,39 @@ constants_list = [
     'dyn', 'lbf', 'kgf', 'IMF',
 ]
 
+
 class TestConstant(unittest.TestCase):
 
     def test_constants(self):
         import brainunit.constants as constants
 
         # Check that the expected names exist and have the correct dimensions
-        assert constants.avogadro_constant.dim == (1 / mole).dim
-        assert constants.boltzmann_constant.dim == (joule / kelvin).dim
-        assert constants.electric_constant.dim == (farad / meter).dim
+        assert constants.avogadro.dim == (1 / mole).dim
+        assert constants.boltzmann.dim == (joule / kelvin).dim
+        assert constants.electric.dim == (farad / meter).dim
         assert constants.electron_mass.dim == kilogram.dim
         assert constants.elementary_charge.dim == coulomb.dim
-        assert constants.faraday_constant.dim == (coulomb / mole).dim
-        assert constants.gas_constant.dim == (joule / mole / kelvin).dim
-        assert constants.magnetic_constant.dim == (newton / amp2).dim
-        assert constants.molar_mass_constant.dim == (kilogram / mole).dim
+        assert constants.faraday.dim == (coulomb / mole).dim
+        assert constants.gas.dim == (joule / mole / kelvin).dim
+        assert constants.magnetic.dim == (newton / amp2).dim
+        assert constants.molar_mass.dim == (kilogram / mole).dim
         assert constants.zero_celsius.dim == kelvin.dim
 
         # Check the consistency between a few constants
         assert u.math.allclose(
-            constants.gas_constant.mantissa,
-            (constants.avogadro_constant * constants.boltzmann_constant).mantissa,
+            constants.gas.mantissa,
+            (constants.avogadro * constants.boltzmann).mantissa,
         )
         assert u.math.allclose(
-            constants.faraday_constant.mantissa,
-            (constants.avogadro_constant * constants.elementary_charge).mantissa,
+            constants.faraday.mantissa,
+            (constants.avogadro * constants.elementary_charge).mantissa,
         )
+
     def test_quantity_constants_and_unit_constants(self):
         import brainunit.constants as quantity_constants
         import brainunit._unit_constants as unit_constants
         for c in constants_list:
             q_c = getattr(quantity_constants, c)
             u_c = getattr(unit_constants, c)
-            assert q_c.to_decimal(q_c.unit) == (1. * u_c).to_decimal(q_c.unit), f"Mismatch between {c} in quantity_constants and unit_constants"
+            assert q_c.to_decimal(q_c.unit) == (1. * u_c).to_decimal(
+                q_c.unit), f"Mismatch between {c} in quantity_constants and unit_constants"


### PR DESCRIPTION
This pull request includes significant updates to the `brainunit` package, focusing on improving the organization and accessibility of unit constants and compatibility with older versions. The most important changes include the reorganization of `__all__` lists, the addition of old version compatibility constants, and the renaming of several constants for consistency.

Reorganization and accessibility improvements:

* [`brainunit/__init__.py`](diffhunk://#diff-3a761c6195ec8c8c5d803159623e15bbc65324db5a4ecf797afd0193da93c189L35-R61): Reorganized the `__all__` list for better readability and added compatibility constants for old versions.
* [`brainunit/_unit_constants.py`](diffhunk://#diff-9f81eaed397bf4834438dee224b1f037c0619563c78035f1a863bd2e8bf9024fR20-R31): Added a comprehensive `__all__` list to ensure all unit constants are accessible.

Consistency and compatibility updates:

* [`brainunit/constants.py`](diffhunk://#diff-554e39552dd36c314599882b7d9aff2ebd546d05fbac389ad1f61ec42dcb721fL54-R95): Renamed several constants (e.g., `avogadro_constant` to `avogadro`) and updated the `__all__` list to include all relevant constants.