### PR TITLE
[doc] Update "Functions that Checking Units or Assigning Units" and Fix some typo

### DIFF
--- a/brainunit/_unit_constants.py
+++ b/brainunit/_unit_constants.py
@@ -87,10 +87,10 @@ light_year = Unit.create(meter.dim, name="light year", dispname="ly", scale=mete
 parsec = Unit.create(meter.dim, name="parsec", dispname="pc", scale=meter.scale + 16, factor=3.085677581491367e16)
 
 # ----- Pressure -----
-atm = atmosphere = Unit.create(pascal.dim, name="atmosphere", dispname="atm", scale=meter.scale + 5, factor=1.013249966)
-bar = Unit.create(pascal.dim, name="bar", dispname="bar", scale=meter.scale + 5, factor=1.)
-mmHg = torr = Unit.create(pascal.dim, name="torr", dispname="torr", scale=meter.scale + 2, factor=1.3332236842105263)
-psi = Unit.create(pascal.dim, name="pound per square inch", dispname="psi", scale=meter.scale + 3,
+atm = atmosphere = Unit.create(pascal.dim, name="atmosphere", dispname="atm", scale=pascal.scale + 5, factor=1.013249966)
+bar = Unit.create(pascal.dim, name="bar", dispname="bar", scale=pascal.scale + 5, factor=1.)
+mmHg = torr = Unit.create(pascal.dim, name="torr", dispname="torr", scale=pascal.scale + 2, factor=1.3332236842105263)
+psi = Unit.create(pascal.dim, name="pound per square inch", dispname="psi", scale=pascal.scale + 3,
                   factor=6.894757293168361)
 
 # ----- Area -----
@@ -122,7 +122,7 @@ degree_Fahrenheit = Unit.create(kelvin.dim, name="degree Fahrenheit", dispname="
                                 factor=2.55927778)
 
 # ----- Energy -----
-eV = electron_volt = Unit.create(joule.dim, name="electronvolt", dispname="eV", scale=-19, factor=1.602176565)
+eV = electron_volt = Unit.create(joule.dim, name="electronvolt", dispname="eV", scale=joule.scale - 19, factor=1.602176565)
 calorie = calorie_th = Unit.create(joule.dim, name="calorie", dispname="cal", scale=joule.scale, factor=4.184)
 calorie_IT = Unit.create(joule.dim, name="calorie (International Table)", dispname="cal IT", scale=joule.scale,
                          factor=4.1868)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -164,10 +164,13 @@ We are building the `brain dynamics programming ecosystem <https://ecosystem-for
    :maxdepth: 1
    :caption: Unit-aware Math Functions
 
+   mathematical_functions/customize_functions.ipynb
    mathematical_functions/array_creation.ipynb
    mathematical_functions/numpy_functions.ipynb
    mathematical_functions/elinstein_operations.ipynb
-   mathematical_functions/customize_functions.ipynb
+   mathematical_functions/linalg_functions.ipynb
+   mathematical_functions/fft_functions.ipynb
+   mathematical_functions/lax_functions.ipynb
 
 
 .. toctree::

--- a/docs/mathematical_functions/customize_functions.ipynb
+++ b/docs/mathematical_functions/customize_functions.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Functions that Checking Units\n",
+    "# Functions that Checking Units or Assigning Units\n",
     "\n",
     "[![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/chaobrain/brainunit/blob/master/docs/mathematical_functions/customize_functions.ipynb)\n",
     "[![Open in Kaggle](https://kaggle.com/static/images/open-in-kaggle.svg)](https://kaggle.com/kernels/welcome?src=https://github.com/chaobrain/brainunit/blob/master/docs/mathematical_functions/customize_functions.ipynb)"
@@ -21,66 +21,196 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## `check_units` Decorator"
+    "## Checking Units"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `check_units` decorator allows us to specify the units that function parameters and return values should have. If the provided units are incorrect, it raises a `DimensionMismatchError`."
+    "### `check_dims` Decorator"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Example\n",
-    "Let's demonstrate the usage of the `check_units` decorator through a set of test cases.\n"
+    "The `check_dims` decorator is used to validate the dimensions of input arguments or return values of a function. It ensures that the dimensions match the expected dimensions, helping to avoid errors caused by unit mismatches.\n",
+    "\n",
+    "We will demonstrate the usage of `check_dims` through several examples."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Basic Usage\n",
+    "We can use the `check_dims` decorator to validate whether the input arguments of a function have the expected units."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
     "import brainunit as u\n",
-    "from brainunit import check_units\n",
     "\n",
-    "@check_units(v=u.volt)\n",
-    "def f(v, x):\n",
-    "    '''\n",
-    "    v must have units of volt, x can have any (or no) units\n",
-    "    '''\n",
+    "@u.check_dims(v=u.volt.dim)\n",
+    "def a_function(v, x):\n",
+    "    \"\"\"\n",
+    "    v must have units of volt, and x can have any (or no) unit.\n",
+    "    \"\"\"\n",
     "    pass"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 3,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "# Correct units\n",
-    "f(3 * u.mV, 5 * u.second)\n",
-    "f(5 * u.volt, \"something\")\n",
-    "f([1, 2, 3] * u.volt, None)"
+    "##### Correct Dimensions\n",
+    "The following calls are correct because the `v` argument has units of volt or are `strings` or `None`:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Lists that can be converted should also work\n",
-    "f([1 * u.volt, 2 * u.volt, 3 * u.volt], None)"
+    "a_function(3 * u.mV, 5 * u.second)\n",
+    "a_function(5 * u.volt, \"something\")\n",
+    "a_function([1, 2, 3] * u.volt, None)\n",
+    "a_function([1 * u.volt, 2 * u.volt, 3 * u.volt], None)\n",
+    "a_function(\"a string\", None)\n",
+    "a_function(None, None)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Incorrect Units\n",
+    "The following calls will raise a `DimensionMismatchError` because the `v` argument does not have the expected units."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Function 'a_function' expected a array with dimension metre ** 2 * kilogram * second ** -3 * amp ** -1 for argument 'v' but got '5 * second' (unit is s).\n",
+      "Function 'a_function' expected a array with dimension metre ** 2 * kilogram * second ** -3 * amp ** -1 for argument 'v' but got '5 * Unit(10.0^0)' (unit is 1).\n",
+      "Function 'a_function' expected a array with dimension metre ** 2 * kilogram * second ** -3 * amp ** -1 for argument 'v' but got '<object object at 0x00000193E231BCD0> * Unit(10.0^0)' (unit is 1).\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    a_function(5 * u.second, None)\n",
+    "except u.DimensionMismatchError as e:\n",
+    "    print(e)\n",
+    "    \n",
+    "try:\n",
+    "    a_function(5, None)\n",
+    "except u.DimensionMismatchError as e:\n",
+    "    print(e)\n",
+    "    \n",
+    "try:\n",
+    "    a_function(object(), None)\n",
+    "except u.DimensionMismatchError as e:\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Validating Return Values\n",
+    "\n",
+    "The `check_dims` decorator can also be used to validate whether the return value of a function has the expected dimensions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@u.check_dims(result=u.second.dim)\n",
+    "def b_function(return_second):\n",
+    "    \"\"\"\n",
+    "    If return_second is True, return a value in seconds; otherwise, return a value in volts.\n",
+    "    \"\"\"\n",
+    "    if return_second:\n",
+    "        return 5 * u.second\n",
+    "    else:\n",
+    "        return 3 * u.volt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Correct Return Value\n",
+    "The following call is correct because the return value has dimensions of seconds."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "5 * second"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "b_function(True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Incorrect Return Value\n",
+    "The following call will raise a `DimensionMismatchError` because the return value has dimensions of volts instead of seconds."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The return value of function 'b_function' was expected to have dimension s but was '3 * volt' (unit is m^2 kg s^-3 A^-1).\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    b_function(False)\n",
+    "except u.DimensionMismatchError as e:\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -90,18 +220,189 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Validating Multiple Return Values\n",
+    "\n",
+    "The `check_dims` decorator can also validate multiple return values to ensure they have the expected dimensions."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@u.check_dims(result=(u.second.dim, u.volt.dim))\n",
+    "def d_function(true_result):\n",
+    "    \"\"\"\n",
+    "    If true_result is True, return values in seconds and volts; otherwise, return values in volts and seconds.\n",
+    "    \"\"\"\n",
+    "    if true_result:\n",
+    "        return 5 * u.second, 3 * u.volt\n",
+    "    else:\n",
+    "        return 3 * u.volt, 5 * u.second"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Correct Return Values\n",
+    "\n",
+    "The following call is correct because the return values have dimensions of seconds and volts, respectively."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(5 * second, 3 * volt)"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "d_function(True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Incorrect Return Values\n",
+    "The following call will raise a `DimensionMismatchError` because the return values are in volts and seconds, which do not match the expected order."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Function 'f' expected a array with unit volt for argument 'v' but got '5. s' (unit is s).\n",
-      "Function 'f' expected a array with unit volt for argument 'v' but got '5.' (unit is 1).\n",
-      "unsupported operand type(s) for /: 'object' and 'int'\n",
-      "Argument 'v' is not a array, expected a array with dimensions V\n"
+      "The return value of function 'd_function' was expected to have dimension s but was '3 * volt' (unit is m^2 kg s^-3 A^-1).\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    d_function(False)\n",
+    "except u.DimensionMismatchError as e:\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Validating Dictionary Return Values\n",
+    "The `check_dims` decorator can also validate dictionary return values to ensure they have the expected dimensions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@u.check_dims(result={'u': u.second.dim, 'v': (u.volt.dim, u.metre.dim)})\n",
+    "def d_function2(true_result):\n",
+    "    \"\"\"\n",
+    "    Return different dictionary results based on the value of true_result.\n",
+    "    \"\"\"\n",
+    "    if true_result == 0:\n",
+    "        return {'u': 5 * u.second, 'v': (3 * u.volt, 2 * u.metre)}\n",
+    "    elif true_result == 1:\n",
+    "        return 3 * u.volt, 5 * u.second\n",
+    "    else:\n",
+    "        return {'u': 5 * u.second, 'v': (3 * u.volt, 2 * u.volt)}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Correct Return Values\n",
+    "The following call is correct because the return values match the expected units."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'u': 5 * second, 'v': (3 * volt, 2 * metre)}"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "d_function2(0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Incorrect Return Values\n",
+    "The following calls will raise a `TypeError` or `DimensionMismatchError` because the return values do not match the expected dimensions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Expected a return value of type {'u': second, 'v': (metre ** 2 * kilogram * second ** -3 * amp ** -1, metre)} but got (3 * volt, 5 * second)\n",
+      "The return value of function 'd_function2' was expected to have dimension m but was '2 * volt' (unit is m^2 kg s^-3 A^-1).\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    d_function2(1)\n",
+    "except TypeError as e:\n",
+    "    print(e)\n",
+    "try:\n",
+    "    d_function2(2)\n",
+    "except u.DimensionMismatchError as e:\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Function 'f' expected a array with dimension metre ** 2 * kilogram * second ** -3 * amp ** -1 for argument 'v' but got '5 * second' (unit is s).\n",
+      "Function 'f' expected a array with dimension metre ** 2 * kilogram * second ** -3 * amp ** -1 for argument 'v' but got '5 * Unit(10.0^0)' (unit is 1).\n",
+      "Function 'f' expected a array with dimension metre ** 2 * kilogram * second ** -3 * amp ** -1 for argument 'v' but got '<object object at 0x00000193E231BD90> * Unit(10.0^0)' (unit is 1).\n",
+      "Argument 'v' is not a array, expected a array with dimensions m^2 kg s^-3 A^-1\n"
      ]
     }
    ],
@@ -134,11 +435,42 @@
    "source": [
     "Through these test cases, we can ensure that our functions behave correctly when handling quantities and can handle unit mismatches."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `check_units` Decorator\n",
+    "The `check_units` decorator allows us to specify the units that function parameters and return values should have. If the provided units are incorrect, it raises a `UnitMismatchError`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import brainunit as u\n",
+    "\n",
+    "@u.check_units(v=u.volt.dim)\n",
+    "def f(v, x):\n",
+    "    '''\n",
+    "    v must have units of volt, x can have any (or no) units\n",
+    "    '''\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "brainunit",
    "language": "python",
    "name": "python3"
   },
@@ -152,7 +484,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,

--- a/docs/mathematical_functions/customize_functions.ipynb
+++ b/docs/mathematical_functions/customize_functions.ipynb
@@ -50,11 +50,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
     "import brainunit as u\n",
+    "from brainunit import volt, meter, second, check_dims, check_units, assign_units\n",
     "\n",
     "@u.check_dims(v=u.volt.dim)\n",
     "def a_function(v, x):\n",
@@ -461,16 +462,457 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `check_units` Decorator"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `check_units` decorator is used to validate the dimensions of input arguments or return values of a function. It ensures that the dimensions match the expected dimensions, helping to avoid errors caused by unit mismatches.\n",
+    "\n",
+    "We will demonstrate the usage of `check_units` through several examples."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Basic Usage\n",
+    "We can use the `check_units` decorator to validate whether the input arguments of a function have the expected units."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import brainunit as u\n",
+    "\n",
+    "@u.check_units(v=u.volt)\n",
+    "def a_function(v, x):\n",
+    "    \"\"\"\n",
+    "    v must have units of volt, and x can have any (or no) unit.\n",
+    "    \"\"\"\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Correct Dimensions\n",
+    "The following calls are correct because the `v` argument has units of volt or are `strings` or `None`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "UnitMismatchError",
+     "evalue": "Function 'a_function' expected a array with unit volt for argument 'v' but got '3 * mvolt' (unit is mV).",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mUnitMismatchError\u001b[0m                         Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[3], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43ma_function\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m3\u001b[39;49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43m \u001b[49m\u001b[43mu\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mmV\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m5\u001b[39;49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43m \u001b[49m\u001b[43mu\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43msecond\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m      2\u001b[0m a_function(\u001b[38;5;241m5\u001b[39m \u001b[38;5;241m*\u001b[39m u\u001b[38;5;241m.\u001b[39mvolt, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124msomething\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m      3\u001b[0m a_function([\u001b[38;5;241m1\u001b[39m, \u001b[38;5;241m2\u001b[39m, \u001b[38;5;241m3\u001b[39m] \u001b[38;5;241m*\u001b[39m u\u001b[38;5;241m.\u001b[39mvolt, \u001b[38;5;28;01mNone\u001b[39;00m)\n",
+      "File \u001b[0;32m~/miniconda3/envs/brainpy-dev/lib/python3.12/site-packages/brainunit/_base.py:4725\u001b[0m, in \u001b[0;36mcheck_units.<locals>.do_check_units.<locals>.new_f\u001b[0;34m(*args, **kwds)\u001b[0m\n\u001b[1;32m   4718\u001b[0m             value \u001b[38;5;241m=\u001b[39m newkeyset[k]\n\u001b[1;32m   4719\u001b[0m             error_message \u001b[38;5;241m=\u001b[39m (\n\u001b[1;32m   4720\u001b[0m                 \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mFunction \u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mf\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m \u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m   4721\u001b[0m                 \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mexpected a array with unit \u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m   4722\u001b[0m                 \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;132;01m{\u001b[39;00munit\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m for argument \u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mk\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m but got \u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m   4723\u001b[0m                 \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mvalue\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m   4724\u001b[0m             )\n\u001b[0;32m-> 4725\u001b[0m             \u001b[38;5;28;01mraise\u001b[39;00m UnitMismatchError(error_message, get_unit(newkeyset[k]))\n\u001b[1;32m   4727\u001b[0m result \u001b[38;5;241m=\u001b[39m f(\u001b[38;5;241m*\u001b[39margs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwds)\n\u001b[1;32m   4728\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mresult\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;129;01min\u001b[39;00m au:\n",
+      "\u001b[0;31mUnitMismatchError\u001b[0m: Function 'a_function' expected a array with unit volt for argument 'v' but got '3 * mvolt' (unit is mV)."
+     ]
+    }
+   ],
+   "source": [
+    "a_function(3 * volt, 5 * second)\n",
+    "a_function(5 * volt, \"something\")\n",
+    "a_function([1, 2, 3] * volt, None)\n",
+    "# lists that can be converted should also work\n",
+    "a_function([1 * volt, 2 * volt, 3 * volt], None)\n",
+    "# Strings and None are also allowed to pass\n",
+    "a_function(\"a string\", None)\n",
+    "a_function(None, None)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Incorrect Units\n",
+    "The following calls will raise a `DimensionMismatchError` because the `v` argument does not have the expected units."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Function 'a_function' expected a array with dimension metre ** 2 * kilogram * second ** -3 * amp ** -1 for argument 'v' but got '5 * second' (unit is s).\n",
+      "Function 'a_function' expected a array with dimension metre ** 2 * kilogram * second ** -3 * amp ** -1 for argument 'v' but got '5 * Unit(10.0^0)' (unit is 1).\n",
+      "Function 'a_function' expected a array with dimension metre ** 2 * kilogram * second ** -3 * amp ** -1 for argument 'v' but got '<object object at 0x00000193E231BCD0> * Unit(10.0^0)' (unit is 1).\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    a_function(5 * u.second, None)\n",
+    "except u.DimensionMismatchError as e:\n",
+    "    print(e)\n",
+    "    \n",
+    "try:\n",
+    "    a_function(5, None)\n",
+    "except u.DimensionMismatchError as e:\n",
+    "    print(e)\n",
+    "    \n",
+    "try:\n",
+    "    a_function(object(), None)\n",
+    "except u.DimensionMismatchError as e:\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Validating Return Values\n",
+    "\n",
+    "The `check_dims` decorator can also be used to validate whether the return value of a function has the expected dimensions."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "@u.check_dims(result=u.second.dim)\n",
+    "def b_function(return_second):\n",
+    "    \"\"\"\n",
+    "    If return_second is True, return a value in seconds; otherwise, return a value in volts.\n",
+    "    \"\"\"\n",
+    "    if return_second:\n",
+    "        return 5 * u.second\n",
+    "    else:\n",
+    "        return 3 * u.volt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Correct Return Value\n",
+    "The following call is correct because the return value has dimensions of seconds."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "5 * second"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "b_function(True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Incorrect Return Value\n",
+    "The following call will raise a `DimensionMismatchError` because the return value has dimensions of volts instead of seconds."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The return value of function 'b_function' was expected to have dimension s but was '3 * volt' (unit is m^2 kg s^-3 A^-1).\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    b_function(False)\n",
+    "except u.DimensionMismatchError as e:\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Strings and None are also allowed to pass\n",
+    "f(\"a string\", None)\n",
+    "f(None, None)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Validating Multiple Return Values\n",
+    "\n",
+    "The `check_dims` decorator can also validate multiple return values to ensure they have the expected dimensions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@u.check_dims(result=(u.second.dim, u.volt.dim))\n",
+    "def d_function(true_result):\n",
+    "    \"\"\"\n",
+    "    If true_result is True, return values in seconds and volts; otherwise, return values in volts and seconds.\n",
+    "    \"\"\"\n",
+    "    if true_result:\n",
+    "        return 5 * u.second, 3 * u.volt\n",
+    "    else:\n",
+    "        return 3 * u.volt, 5 * u.second"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Correct Return Values\n",
+    "\n",
+    "The following call is correct because the return values have dimensions of seconds and volts, respectively."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(5 * second, 3 * volt)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "d_function(True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Incorrect Return Values\n",
+    "The following call will raise a `DimensionMismatchError` because the return values are in volts and seconds, which do not match the expected order."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The return value of function 'd_function' was expected to have dimension s but was '3 * volt' (unit is m^2 kg s^-3 A^-1).\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    d_function(False)\n",
+    "except u.DimensionMismatchError as e:\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Validating Dictionary Return Values\n",
+    "The `check_dims` decorator can also validate dictionary return values to ensure they have the expected dimensions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@u.check_dims(result={'u': u.second.dim, 'v': (u.volt.dim, u.metre.dim)})\n",
+    "def d_function2(true_result):\n",
+    "    \"\"\"\n",
+    "    Return different dictionary results based on the value of true_result.\n",
+    "    \"\"\"\n",
+    "    if true_result == 0:\n",
+    "        return {'u': 5 * u.second, 'v': (3 * u.volt, 2 * u.metre)}\n",
+    "    elif true_result == 1:\n",
+    "        return 3 * u.volt, 5 * u.second\n",
+    "    else:\n",
+    "        return {'u': 5 * u.second, 'v': (3 * u.volt, 2 * u.volt)}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Correct Return Values\n",
+    "The following call is correct because the return values match the expected units."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'u': 5 * second, 'v': (3 * volt, 2 * metre)}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "d_function2(0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Incorrect Return Values\n",
+    "The following calls will raise a `TypeError` or `DimensionMismatchError` because the return values do not match the expected dimensions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Expected a return value of type {'u': second, 'v': (metre ** 2 * kilogram * second ** -3 * amp ** -1, metre)} but got (3 * volt, 5 * second)\n",
+      "The return value of function 'd_function2' was expected to have dimension m but was '2 * volt' (unit is m^2 kg s^-3 A^-1).\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    d_function2(1)\n",
+    "except TypeError as e:\n",
+    "    print(e)\n",
+    "try:\n",
+    "    d_function2(2)\n",
+    "except u.DimensionMismatchError as e:\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Function 'f' expected a array with dimension metre ** 2 * kilogram * second ** -3 * amp ** -1 for argument 'v' but got '5 * second' (unit is s).\n",
+      "Function 'f' expected a array with dimension metre ** 2 * kilogram * second ** -3 * amp ** -1 for argument 'v' but got '5 * Unit(10.0^0)' (unit is 1).\n",
+      "Function 'f' expected a array with dimension metre ** 2 * kilogram * second ** -3 * amp ** -1 for argument 'v' but got '<object object at 0x00000193E231BD90> * Unit(10.0^0)' (unit is 1).\n",
+      "Argument 'v' is not a array, expected a array with dimensions m^2 kg s^-3 A^-1\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Incorrect units\n",
+    "try:\n",
+    "    f(5 * u.second, None)\n",
+    "except Exception as e:\n",
+    "    print(e)\n",
+    "\n",
+    "try:\n",
+    "    f(5, None)\n",
+    "except Exception as e:\n",
+    "    print(e)\n",
+    "\n",
+    "try:\n",
+    "    f(object(), None)\n",
+    "except Exception as e:\n",
+    "    print(e)\n",
+    "\n",
+    "try:\n",
+    "    f([1, 2 * u.volt, 3], None)\n",
+    "except Exception as e:\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Through these test cases, we can ensure that our functions behave correctly when handling quantities and can handle unit mismatches."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `check_units` Decorator\n",
+    "The `check_units` decorator allows us to specify the units that function parameters and return values should have. If the provided units are incorrect, it raises a `UnitMismatchError`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import brainunit as u\n",
+    "\n",
+    "@u.check_units(v=u.volt.dim)\n",
+    "def f(v, x):\n",
+    "    '''\n",
+    "    v must have units of volt, x can have any (or no) units\n",
+    "    '''\n",
+    "    pass"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "brainunit",
+   "display_name": "brainpy-dev",
    "language": "python",
    "name": "python3"
   },
@@ -484,7 +926,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.15"
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,

--- a/docs/mathematical_functions/customize_functions.ipynb
+++ b/docs/mathematical_functions/customize_functions.ipynb
@@ -21,6 +21,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "First, we need to import the necessary libraries and modules."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import brainunit\n",
+    "from brainunit import volt, mV, meter, second, check_dims, check_units, assign_units, DimensionMismatchError, UnitMismatchError"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Checking Units"
    ]
   },
@@ -50,14 +67,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import brainunit as u\n",
-    "from brainunit import volt, meter, second, check_dims, check_units, assign_units\n",
-    "\n",
-    "@u.check_dims(v=u.volt.dim)\n",
+    "@check_dims(v=volt.dim)\n",
     "def a_function(v, x):\n",
     "    \"\"\"\n",
     "    v must have units of volt, and x can have any (or no) unit.\n",
@@ -75,14 +89,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [],
    "source": [
-    "a_function(3 * u.mV, 5 * u.second)\n",
-    "a_function(5 * u.volt, \"something\")\n",
-    "a_function([1, 2, 3] * u.volt, None)\n",
-    "a_function([1 * u.volt, 2 * u.volt, 3 * u.volt], None)\n",
+    "a_function(3 * mV, 5 * second)\n",
+    "a_function(5 * volt, \"something\")\n",
+    "a_function([1, 2, 3] * volt, None)\n",
+    "a_function([1 * volt, 2 * volt, 3 * volt], None)\n",
     "a_function(\"a string\", None)\n",
     "a_function(None, None)"
    ]
@@ -97,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [
     {
@@ -106,24 +120,24 @@
      "text": [
       "Function 'a_function' expected a array with dimension metre ** 2 * kilogram * second ** -3 * amp ** -1 for argument 'v' but got '5 * second' (unit is s).\n",
       "Function 'a_function' expected a array with dimension metre ** 2 * kilogram * second ** -3 * amp ** -1 for argument 'v' but got '5 * Unit(10.0^0)' (unit is 1).\n",
-      "Function 'a_function' expected a array with dimension metre ** 2 * kilogram * second ** -3 * amp ** -1 for argument 'v' but got '<object object at 0x00000193E231BCD0> * Unit(10.0^0)' (unit is 1).\n"
+      "Function 'a_function' expected a array with dimension metre ** 2 * kilogram * second ** -3 * amp ** -1 for argument 'v' but got '<object object at 0x00000193E267C540> * Unit(10.0^0)' (unit is 1).\n"
      ]
     }
    ],
    "source": [
     "try:\n",
-    "    a_function(5 * u.second, None)\n",
-    "except u.DimensionMismatchError as e:\n",
+    "    a_function(5 * second, None)\n",
+    "except DimensionMismatchError as e:\n",
     "    print(e)\n",
     "    \n",
     "try:\n",
     "    a_function(5, None)\n",
-    "except u.DimensionMismatchError as e:\n",
+    "except DimensionMismatchError as e:\n",
     "    print(e)\n",
     "    \n",
     "try:\n",
     "    a_function(object(), None)\n",
-    "except u.DimensionMismatchError as e:\n",
+    "except DimensionMismatchError as e:\n",
     "    print(e)"
    ]
   },
@@ -138,19 +152,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [],
    "source": [
-    "@u.check_dims(result=u.second.dim)\n",
+    "@check_dims(result=second.dim)\n",
     "def b_function(return_second):\n",
     "    \"\"\"\n",
     "    If return_second is True, return a value in seconds; otherwise, return a value in volts.\n",
     "    \"\"\"\n",
     "    if return_second:\n",
-    "        return 5 * u.second\n",
+    "        return 5 * second\n",
     "    else:\n",
-    "        return 3 * u.volt"
+    "        return 3 * volt"
    ]
   },
   {
@@ -163,7 +177,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [
     {
@@ -172,7 +186,7 @@
        "5 * second"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 48,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -191,7 +205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [
     {
@@ -205,19 +219,8 @@
    "source": [
     "try:\n",
     "    b_function(False)\n",
-    "except u.DimensionMismatchError as e:\n",
+    "except DimensionMismatchError as e:\n",
     "    print(e)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Strings and None are also allowed to pass\n",
-    "f(\"a string\", None)\n",
-    "f(None, None)"
    ]
   },
   {
@@ -231,19 +234,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 51,
    "metadata": {},
    "outputs": [],
    "source": [
-    "@u.check_dims(result=(u.second.dim, u.volt.dim))\n",
+    "@check_dims(result=(second.dim, volt.dim))\n",
     "def d_function(true_result):\n",
     "    \"\"\"\n",
     "    If true_result is True, return values in seconds and volts; otherwise, return values in volts and seconds.\n",
     "    \"\"\"\n",
     "    if true_result:\n",
-    "        return 5 * u.second, 3 * u.volt\n",
+    "        return 5 * second, 3 * volt\n",
     "    else:\n",
-    "        return 3 * u.volt, 5 * u.second"
+    "        return 3 * volt, 5 * second"
    ]
   },
   {
@@ -257,7 +260,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 52,
    "metadata": {},
    "outputs": [
     {
@@ -266,7 +269,7 @@
        "(5 * second, 3 * volt)"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 52,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -285,7 +288,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 53,
    "metadata": {},
    "outputs": [
     {
@@ -299,7 +302,7 @@
    "source": [
     "try:\n",
     "    d_function(False)\n",
-    "except u.DimensionMismatchError as e:\n",
+    "except DimensionMismatchError as e:\n",
     "    print(e)"
    ]
   },
@@ -313,21 +316,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 55,
    "metadata": {},
    "outputs": [],
    "source": [
-    "@u.check_dims(result={'u': u.second.dim, 'v': (u.volt.dim, u.metre.dim)})\n",
+    "@check_dims(result={'u': second.dim, 'v': (volt.dim, meter.dim)})\n",
     "def d_function2(true_result):\n",
     "    \"\"\"\n",
     "    Return different dictionary results based on the value of true_result.\n",
     "    \"\"\"\n",
     "    if true_result == 0:\n",
-    "        return {'u': 5 * u.second, 'v': (3 * u.volt, 2 * u.metre)}\n",
+    "        return {'u': 5 * second, 'v': (3 * volt, 2 * meter)}\n",
     "    elif true_result == 1:\n",
-    "        return 3 * u.volt, 5 * u.second\n",
+    "        return 3 * volt, 5 * second\n",
     "    else:\n",
-    "        return {'u': 5 * u.second, 'v': (3 * u.volt, 2 * u.volt)}"
+    "        return {'u': 5 * second, 'v': (3 * volt, 2 * volt)}"
    ]
   },
   {
@@ -335,21 +338,21 @@
    "metadata": {},
    "source": [
     "##### Correct Return Values\n",
-    "The following call is correct because the return values match the expected units."
+    "The following call is correct because the return values match the expected dimensions."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 56,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'u': 5 * second, 'v': (3 * volt, 2 * metre)}"
+       "{'u': 5 * second, 'v': (3 * volt, 2 * meter)}"
       ]
      },
-     "execution_count": 37,
+     "execution_count": 56,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -368,7 +371,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 57,
    "metadata": {},
    "outputs": [
     {
@@ -387,78 +390,8 @@
     "    print(e)\n",
     "try:\n",
     "    d_function2(2)\n",
-    "except u.DimensionMismatchError as e:\n",
+    "except DimensionMismatchError as e:\n",
     "    print(e)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Function 'f' expected a array with dimension metre ** 2 * kilogram * second ** -3 * amp ** -1 for argument 'v' but got '5 * second' (unit is s).\n",
-      "Function 'f' expected a array with dimension metre ** 2 * kilogram * second ** -3 * amp ** -1 for argument 'v' but got '5 * Unit(10.0^0)' (unit is 1).\n",
-      "Function 'f' expected a array with dimension metre ** 2 * kilogram * second ** -3 * amp ** -1 for argument 'v' but got '<object object at 0x00000193E231BD90> * Unit(10.0^0)' (unit is 1).\n",
-      "Argument 'v' is not a array, expected a array with dimensions m^2 kg s^-3 A^-1\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Incorrect units\n",
-    "try:\n",
-    "    f(5 * u.second, None)\n",
-    "except Exception as e:\n",
-    "    print(e)\n",
-    "\n",
-    "try:\n",
-    "    f(5, None)\n",
-    "except Exception as e:\n",
-    "    print(e)\n",
-    "\n",
-    "try:\n",
-    "    f(object(), None)\n",
-    "except Exception as e:\n",
-    "    print(e)\n",
-    "\n",
-    "try:\n",
-    "    f([1, 2 * u.volt, 3], None)\n",
-    "except Exception as e:\n",
-    "    print(e)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Through these test cases, we can ensure that our functions behave correctly when handling quantities and can handle unit mismatches."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### `check_units` Decorator\n",
-    "The `check_units` decorator allows us to specify the units that function parameters and return values should have. If the provided units are incorrect, it raises a `UnitMismatchError`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import brainunit as u\n",
-    "\n",
-    "@u.check_units(v=u.volt.dim)\n",
-    "def f(v, x):\n",
-    "    '''\n",
-    "    v must have units of volt, x can have any (or no) units\n",
-    "    '''\n",
-    "    pass"
    ]
   },
   {
@@ -487,13 +420,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 59,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import brainunit as u\n",
-    "\n",
-    "@u.check_units(v=u.volt)\n",
+    "@check_units(v=volt)\n",
     "def a_function(v, x):\n",
     "    \"\"\"\n",
     "    v must have units of volt, and x can have any (or no) unit.\n",
@@ -511,22 +442,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 60,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "UnitMismatchError",
-     "evalue": "Function 'a_function' expected a array with unit volt for argument 'v' but got '3 * mvolt' (unit is mV).",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mUnitMismatchError\u001b[0m                         Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[3], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43ma_function\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m3\u001b[39;49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43m \u001b[49m\u001b[43mu\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mmV\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m5\u001b[39;49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43m \u001b[49m\u001b[43mu\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43msecond\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m      2\u001b[0m a_function(\u001b[38;5;241m5\u001b[39m \u001b[38;5;241m*\u001b[39m u\u001b[38;5;241m.\u001b[39mvolt, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124msomething\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m      3\u001b[0m a_function([\u001b[38;5;241m1\u001b[39m, \u001b[38;5;241m2\u001b[39m, \u001b[38;5;241m3\u001b[39m] \u001b[38;5;241m*\u001b[39m u\u001b[38;5;241m.\u001b[39mvolt, \u001b[38;5;28;01mNone\u001b[39;00m)\n",
-      "File \u001b[0;32m~/miniconda3/envs/brainpy-dev/lib/python3.12/site-packages/brainunit/_base.py:4725\u001b[0m, in \u001b[0;36mcheck_units.<locals>.do_check_units.<locals>.new_f\u001b[0;34m(*args, **kwds)\u001b[0m\n\u001b[1;32m   4718\u001b[0m             value \u001b[38;5;241m=\u001b[39m newkeyset[k]\n\u001b[1;32m   4719\u001b[0m             error_message \u001b[38;5;241m=\u001b[39m (\n\u001b[1;32m   4720\u001b[0m                 \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mFunction \u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mf\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m \u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m   4721\u001b[0m                 \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mexpected a array with unit \u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m   4722\u001b[0m                 \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;132;01m{\u001b[39;00munit\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m for argument \u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mk\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m but got \u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m   4723\u001b[0m                 \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mvalue\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m   4724\u001b[0m             )\n\u001b[0;32m-> 4725\u001b[0m             \u001b[38;5;28;01mraise\u001b[39;00m UnitMismatchError(error_message, get_unit(newkeyset[k]))\n\u001b[1;32m   4727\u001b[0m result \u001b[38;5;241m=\u001b[39m f(\u001b[38;5;241m*\u001b[39margs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwds)\n\u001b[1;32m   4728\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mresult\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;129;01min\u001b[39;00m au:\n",
-      "\u001b[0;31mUnitMismatchError\u001b[0m: Function 'a_function' expected a array with unit volt for argument 'v' but got '3 * mvolt' (unit is mV)."
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "a_function(3 * volt, 5 * second)\n",
     "a_function(5 * volt, \"something\")\n",
@@ -548,33 +466,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 62,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Function 'a_function' expected a array with dimension metre ** 2 * kilogram * second ** -3 * amp ** -1 for argument 'v' but got '5 * second' (unit is s).\n",
-      "Function 'a_function' expected a array with dimension metre ** 2 * kilogram * second ** -3 * amp ** -1 for argument 'v' but got '5 * Unit(10.0^0)' (unit is 1).\n",
-      "Function 'a_function' expected a array with dimension metre ** 2 * kilogram * second ** -3 * amp ** -1 for argument 'v' but got '<object object at 0x00000193E231BCD0> * Unit(10.0^0)' (unit is 1).\n"
+      "Function 'a_function' expected a array with unit volt for argument 'v' but got '5 * second' (unit is s).\n",
+      "Function 'a_function' expected a array with unit volt for argument 'v' but got '5 * Unit(10.0^0)' (unit is Unit(10.0^0)).\n",
+      "Function 'a_function' expected a array with unit volt for argument 'v' but got '<object object at 0x00000193E231BEE0> * Unit(10.0^0)' (unit is Unit(10.0^0)).\n"
      ]
     }
    ],
    "source": [
     "try:\n",
-    "    a_function(5 * u.second, None)\n",
-    "except u.DimensionMismatchError as e:\n",
+    "    a_function(5 * second, None)\n",
+    "except UnitMismatchError as e:\n",
     "    print(e)\n",
     "    \n",
     "try:\n",
     "    a_function(5, None)\n",
-    "except u.DimensionMismatchError as e:\n",
+    "except UnitMismatchError as e:\n",
     "    print(e)\n",
     "    \n",
     "try:\n",
     "    a_function(object(), None)\n",
-    "except u.DimensionMismatchError as e:\n",
+    "except UnitMismatchError as e:\n",
     "    print(e)"
    ]
   },
@@ -584,24 +502,25 @@
    "source": [
     "#### Validating Return Values\n",
     "\n",
-    "The `check_dims` decorator can also be used to validate whether the return value of a function has the expected dimensions."
+    "The `check_units` decorator can also be used to validate whether the return value of a function has the expected units."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 63,
    "metadata": {},
    "outputs": [],
    "source": [
-    "@u.check_dims(result=u.second.dim)\n",
+    "@check_units(result=second)\n",
     "def b_function(return_second):\n",
     "    \"\"\"\n",
-    "    If return_second is True, return a value in seconds; otherwise, return a value in volts.\n",
+    "    Return a value in seconds if return_second is True, otherwise return\n",
+    "    a value in volt.\n",
     "    \"\"\"\n",
     "    if return_second:\n",
-    "        return 5 * u.second\n",
+    "        return 5 * second\n",
     "    else:\n",
-    "        return 3 * u.volt"
+    "        return 3 * volt"
    ]
   },
   {
@@ -609,12 +528,12 @@
    "metadata": {},
    "source": [
     "##### Correct Return Value\n",
-    "The following call is correct because the return value has dimensions of seconds."
+    "The following call is correct because the return value has units of seconds."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 64,
    "metadata": {},
    "outputs": [
     {
@@ -623,8 +542,9 @@
        "5 * second"
       ]
      },
+     "execution_count": 64,
      "metadata": {},
-     "output_type": "display_data"
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -636,38 +556,27 @@
    "metadata": {},
    "source": [
     "##### Incorrect Return Value\n",
-    "The following call will raise a `DimensionMismatchError` because the return value has dimensions of volts instead of seconds."
+    "The following call will raise a `UnitMismatchError` because the return value has units of volts instead of seconds."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 66,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The return value of function 'b_function' was expected to have dimension s but was '3 * volt' (unit is m^2 kg s^-3 A^-1).\n"
+      "The return value of function 'b_function' was expected to have unit V but was '3 * volt' (unit is V).\n"
      ]
     }
    ],
    "source": [
     "try:\n",
     "    b_function(False)\n",
-    "except u.DimensionMismatchError as e:\n",
+    "except UnitMismatchError as e:\n",
     "    print(e)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Strings and None are also allowed to pass\n",
-    "f(\"a string\", None)\n",
-    "f(None, None)"
    ]
   },
   {
@@ -676,24 +585,25 @@
    "source": [
     "#### Validating Multiple Return Values\n",
     "\n",
-    "The `check_dims` decorator can also validate multiple return values to ensure they have the expected dimensions."
+    "The `check_units` decorator can also validate multiple return values to ensure they have the expected units."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 67,
    "metadata": {},
    "outputs": [],
    "source": [
-    "@u.check_dims(result=(u.second.dim, u.volt.dim))\n",
+    "@check_units(result=(second, volt))\n",
     "def d_function(true_result):\n",
     "    \"\"\"\n",
-    "    If true_result is True, return values in seconds and volts; otherwise, return values in volts and seconds.\n",
+    "    Return a value in seconds if return_second is True, otherwise return\n",
+    "    a value in volt.\n",
     "    \"\"\"\n",
     "    if true_result:\n",
-    "        return 5 * u.second, 3 * u.volt\n",
+    "        return 5 * second, 3 * volt\n",
     "    else:\n",
-    "        return 3 * u.volt, 5 * u.second"
+    "        return 3 * volt, 5 * second"
    ]
   },
   {
@@ -702,12 +612,12 @@
    "source": [
     "##### Correct Return Values\n",
     "\n",
-    "The following call is correct because the return values have dimensions of seconds and volts, respectively."
+    "The following call is correct because the return values have units of seconds and volts, respectively."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 68,
    "metadata": {},
    "outputs": [
     {
@@ -716,8 +626,9 @@
        "(5 * second, 3 * volt)"
       ]
      },
+     "execution_count": 68,
      "metadata": {},
-     "output_type": "display_data"
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -729,26 +640,26 @@
    "metadata": {},
    "source": [
     "##### Incorrect Return Values\n",
-    "The following call will raise a `DimensionMismatchError` because the return values are in volts and seconds, which do not match the expected order."
+    "The following call will raise a `UnitMismatchError` because the return values are in volts and seconds, which do not match the expected order."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 69,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The return value of function 'd_function' was expected to have dimension s but was '3 * volt' (unit is m^2 kg s^-3 A^-1).\n"
+      "The return value of function 'd_function' was expected to have unit V but was '3 * volt' (unit is V).\n"
      ]
     }
    ],
    "source": [
     "try:\n",
     "    d_function(False)\n",
-    "except u.DimensionMismatchError as e:\n",
+    "except UnitMismatchError as e:\n",
     "    print(e)"
    ]
   },
@@ -757,26 +668,27 @@
    "metadata": {},
    "source": [
     "#### Validating Dictionary Return Values\n",
-    "The `check_dims` decorator can also validate dictionary return values to ensure they have the expected dimensions."
+    "The `check_units` decorator can also validate dictionary return values to ensure they have the expected units."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 71,
    "metadata": {},
    "outputs": [],
    "source": [
-    "@u.check_dims(result={'u': u.second.dim, 'v': (u.volt.dim, u.metre.dim)})\n",
+    "@check_units(result={'u': second, 'v': (volt, meter)})\n",
     "def d_function2(true_result):\n",
     "    \"\"\"\n",
-    "    Return different dictionary results based on the value of true_result.\n",
+    "    Return a value in seconds if return_second is True, otherwise return\n",
+    "    a value in volt.\n",
     "    \"\"\"\n",
     "    if true_result == 0:\n",
-    "        return {'u': 5 * u.second, 'v': (3 * u.volt, 2 * u.metre)}\n",
+    "        return {'u': 5 * second, 'v': (3 * volt, 2 * meter)}\n",
     "    elif true_result == 1:\n",
-    "        return 3 * u.volt, 5 * u.second\n",
+    "        return 3 * volt, 5 * second\n",
     "    else:\n",
-    "        return {'u': 5 * u.second, 'v': (3 * u.volt, 2 * u.volt)}"
+    "        return {'u': 5 * second, 'v': (3 * volt, 2 * volt)}"
    ]
   },
   {
@@ -789,17 +701,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 72,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'u': 5 * second, 'v': (3 * volt, 2 * metre)}"
+       "{'u': 5 * second, 'v': (3 * volt, 2 * meter)}"
       ]
      },
+     "execution_count": 72,
      "metadata": {},
-     "output_type": "display_data"
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -811,20 +724,20 @@
    "metadata": {},
    "source": [
     "##### Incorrect Return Values\n",
-    "The following calls will raise a `TypeError` or `DimensionMismatchError` because the return values do not match the expected dimensions."
+    "The following calls will raise a `TypeError` or `UnitMismatchError` because the return values do not match the expected units."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 74,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Expected a return value of type {'u': second, 'v': (metre ** 2 * kilogram * second ** -3 * amp ** -1, metre)} but got (3 * volt, 5 * second)\n",
-      "The return value of function 'd_function2' was expected to have dimension m but was '2 * volt' (unit is m^2 kg s^-3 A^-1).\n"
+      "Expected a return value of type {'u': second, 'v': (volt, meter)} but got (3 * volt, 5 * second)\n",
+      "The return value of function 'd_function2' was expected to have unit V but was '2 * volt' (unit is V).\n"
      ]
     }
    ],
@@ -835,46 +748,104 @@
     "    print(e)\n",
     "try:\n",
     "    d_function2(2)\n",
-    "except u.DimensionMismatchError as e:\n",
+    "except UnitMismatchError as e:\n",
     "    print(e)"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Assigning Units"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `assign_units` Decorator\n",
+    "The `assign_units` decorator is used to automatically assign units to the input arguments or return values of a function. It ensures that the values are converted to the specified units, simplifying unit handling in scientific computations."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Basic Usage\n",
+    "\n",
+    "We can use the `assign_units` decorator to automatically assign units to the input arguments of a function."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 75,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@assign_units(v=volt)\n",
+    "def a_function(v, x):\n",
+    "    \"\"\"\n",
+    "    v will be assigned units of volt, and x can have any (or no) unit.\n",
+    "    \"\"\"\n",
+    "    return v"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Correct Units\n",
+    "The following calls are correct because the `v` argument is automatically converted to volts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 77,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert a_function(3 * mV, 5 * second) == (3 * mV).to_decimal(volt)\n",
+    "assert a_function(3 * volt, 5 * second) == (3 * volt).to_decimal(volt)\n",
+    "assert a_function(5 * volt, \"something\") == (5 * volt).to_decimal(volt)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Incorrect Units\n",
+    "The following calls will raise a `UnitMismatchError` or `TypeError` because the `v` argument cannot be converted to volts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 78,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Function 'f' expected a array with dimension metre ** 2 * kilogram * second ** -3 * amp ** -1 for argument 'v' but got '5 * second' (unit is s).\n",
-      "Function 'f' expected a array with dimension metre ** 2 * kilogram * second ** -3 * amp ** -1 for argument 'v' but got '5 * Unit(10.0^0)' (unit is 1).\n",
-      "Function 'f' expected a array with dimension metre ** 2 * kilogram * second ** -3 * amp ** -1 for argument 'v' but got '<object object at 0x00000193E231BD90> * Unit(10.0^0)' (unit is 1).\n",
-      "Argument 'v' is not a array, expected a array with dimensions m^2 kg s^-3 A^-1\n"
+      "Cannot convert to the decimal number using a unit with different dimensions. The quantity has the unit s, but the given unit is V\n",
+      "Function 'a_function' expected a Quantity object for argument 'v' but got '5'\n",
+      "Function 'a_function' expected a Quantity object for argument 'v' but got '<object object at 0x00000193E29D4370>'\n"
      ]
     }
    ],
    "source": [
-    "# Incorrect units\n",
     "try:\n",
-    "    f(5 * u.second, None)\n",
-    "except Exception as e:\n",
+    "    a_function(5 * second, None)\n",
+    "except UnitMismatchError as e:\n",
     "    print(e)\n",
     "\n",
     "try:\n",
-    "    f(5, None)\n",
-    "except Exception as e:\n",
+    "    a_function(5, None)\n",
+    "except TypeError as e:\n",
     "    print(e)\n",
     "\n",
     "try:\n",
-    "    f(object(), None)\n",
-    "except Exception as e:\n",
-    "    print(e)\n",
-    "\n",
-    "try:\n",
-    "    f([1, 2 * u.volt, 3], None)\n",
-    "except Exception as e:\n",
+    "    a_function(object(), None)\n",
+    "except TypeError as e:\n",
     "    print(e)"
    ]
   },
@@ -882,31 +853,169 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Through these test cases, we can ensure that our functions behave correctly when handling quantities and can handle unit mismatches."
+    "#### Assigning Units to Return Values\n",
+    "The `assign_units` decorator can also be used to automatically assign units to the return value of a function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 79,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@assign_units(result=second)\n",
+    "def b_function():\n",
+    "    \"\"\"\n",
+    "    The return value will be assigned units of seconds.\n",
+    "    \"\"\"\n",
+    "    return 5"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### `check_units` Decorator\n",
-    "The `check_units` decorator allows us to specify the units that function parameters and return values should have. If the provided units are incorrect, it raises a `UnitMismatchError`."
+    "##### Correct Return Value\n",
+    "The following call is correct because the return value is automatically converted to seconds."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 80,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import brainunit as u\n",
-    "\n",
-    "@u.check_units(v=u.volt.dim)\n",
-    "def f(v, x):\n",
-    "    '''\n",
-    "    v must have units of volt, x can have any (or no) units\n",
-    "    '''\n",
-    "    pass"
+    "assert b_function() == 5 * second"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Assigning Units to Multiple Return Values\n",
+    "The `assign_units` decorator can also assign units to multiple return values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 81,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@assign_units(result=(second, volt))\n",
+    "def d_function():\n",
+    "    \"\"\"\n",
+    "    The return values will be assigned units of seconds and volts, respectively.\n",
+    "    \"\"\"\n",
+    "    return 5, 3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Correct Return Values\n",
+    "The following call is correct because the return values are automatically converted to seconds and volts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 82,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert d_function()[0] == 5 * second\n",
+    "assert d_function()[1] == 3 * volt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Assigning Units to Dictionary Return Values\n",
+    "The `assign_units` decorator can also assign units to dictionary return values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 84,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@assign_units(result={'u': second, 'v': (volt, meter)})\n",
+    "def d_function2(true_result):\n",
+    "    \"\"\"\n",
+    "    The return values will be assigned units based on the dictionary specification.\n",
+    "    \"\"\"\n",
+    "    if true_result == 0:\n",
+    "        return {'u': 5, 'v': (3, 2)}\n",
+    "    elif true_result == 1:\n",
+    "        return 3, 5\n",
+    "    else:\n",
+    "        return 3, 5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Correct Return Values\n",
+    "The following call is correct because the return values are automatically converted to the specified units."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 85,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'u': 5 * second, 'v': (3 * volt, 2 * meter)}"
+      ]
+     },
+     "execution_count": 85,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "d_function2(0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Incorrect Return Values\n",
+    "The following call will raise a `TypeError` because the return values do not match the expected structure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 86,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Expected a return value of type {'u': second, 'v': (volt, meter)} but got (3, 5)\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    d_function2(1)\n",
+    "except TypeError as e:\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Through the examples above, we can see the utility of the `assign_units` decorator in automatically assigning units to input arguments and return values. It simplifies unit handling in scientific computations, ensuring consistency and reducing the likelihood of errors."
    ]
   }
  ],


### PR DESCRIPTION
This pull request includes updates to the `brainunit/_unit_constants.py` file to correct the scale factors for various units and updates to the `docs/index.rst` file to include new documentation links. The most important changes are as follows:

Corrections to unit scale factors:

* [`brainunit/_unit_constants.py`](diffhunk://#diff-9f81eaed397bf4834438dee224b1f037c0619563c78035f1a863bd2e8bf9024fL90-R93): Corrected the scale factors for pressure units (`atmosphere`, `bar`, `torr`, `psi`) to use `pascal.scale` instead of `meter.scale`.
* [`brainunit/_unit_constants.py`](diffhunk://#diff-9f81eaed397bf4834438dee224b1f037c0619563c78035f1a863bd2e8bf9024fL125-R125): Corrected the scale factor for the energy unit `electronvolt` to use `joule.scale - 19` instead of `-19`.

Documentation updates:

* [`docs/index.rst`](diffhunk://#diff-8d068e8797e88947c320f79e856c3e16a72b730124a8f9d7031e2c4680dfa534R167-R173): Added new links to the documentation for `linalg_functions.ipynb`, `fft_functions.ipynb`, and `lax_functions.ipynb`.

## Summary by Sourcery

Clarify the usage of functions for checking and assigning units, and add examples for using decorators.

Enhancements:
- Improve unit scale factor accuracy for pressure and energy units.

Documentation:
- Document the `check_dims`, `check_units`, and `assign_units` decorators with examples.