### PR TITLE
[doc] Add autograd docstring

### DIFF
--- a/brainunit/autograd/_hessian.py
+++ b/brainunit/autograd/_hessian.py
@@ -35,6 +35,20 @@ def hessian(
     Physical unit-aware version of `jax.hessian <https://jax.readthedocs.io/en/latest/_autosummary/jax.hessian.html>`_,
     computing Hessian of ``fun`` as a dense array.
 
+    Example::
+        >>> import jax.numpy as jnp
+        >>> import brainunit as u
+        >>> def scalar_function1(x):
+        ...    return x ** 2 + 3 * x * u.ms + 2 * u.msecond2
+        >>> hess_fn = u.autograd.hessian(scalar_function1)
+        >>> hess_fn(jnp.array(1.0) * u.ms)
+        [2]
+        >>> def scalar_function2(x):
+        ...     return x ** 3 + 3 * x * u.msecond2 + 2 * u.msecond3
+        >>> hess_fn = u.autograd.hessian(scalar_function2)
+        >>> hess_fn(jnp.array(1.0) * u.ms)
+        [6] * ms
+
     Args:
       fun: Function whose Hessian is to be computed.  Its arguments at positions
         specified by ``argnums`` should be arrays, scalars, or standard Python

--- a/brainunit/autograd/_jacobian.py
+++ b/brainunit/autograd/_jacobian.py
@@ -49,6 +49,25 @@ def jacrev(
     """
     Physical unit-aware version of `jax.jacrev <https://jax.readthedocs.io/en/latest/_autosummary/jax.jacrev.html>`_.
 
+    Example::
+            >>> import jax.numpy as jnp
+            >>> import brainunit as u
+            >>> def simple_function1(x):
+            ...    return x ** 2
+            >>> jac_fn = u.autograd.jacrev(simple_function)
+            >>> jac_fn(jnp.array(3.0) * u.ms)
+            6.0 * ms
+            >>> def simple_function2(x, y):
+            ...    return x * y
+            >>> jac_fn = u.autograd.jacrev(simple_function2, argnums=(0, 1))
+            >>> x = jnp.array([3.0, 4.0]) * u.ohm
+            >>> y = jnp.array([5.0, 6.0]) * u.mA
+            >>> jac_fn(x, y)
+            ([[5., 0.],
+              [0., 6.]] * mA,
+             [[3., 0.],
+              [0., 4.]] * ohm)
+
     Args:
         fun: Function whose Jacobian is to be computed.
         argnums: Optional, integer or sequence of integers. Specifies which
@@ -153,6 +172,25 @@ def jacfwd(
 ) -> Callable:
     """
     Physical unit-aware version of `jax.jacfwd <https://jax.readthedocs.io/en/latest/_autosummary/jax.jacfwd.html>`_.
+
+    Example::
+        >>> import jax.numpy as jnp
+        >>> import brainunit as u
+        >>> def simple_function(x):
+        ...    return x ** 2
+        >>> jac_fn = u.autograd.jacfwd(simple_function)
+        >>> jac_fn(jnp.array(3.0) * u.ms)
+        6.0 * ms
+        >>> def simple_function(x, y):
+        ...    return x * y
+        >>> jac_fn = u.autograd.jacfwd(simple_function, argnums=(0, 1))
+        >>> x = jnp.array([3.0, 4.0]) * u.ohm
+        >>> y = jnp.array([5.0, 6.0]) * u.mA
+        >>> jac_fn(x, y)
+        ([[5., 0.],
+          [0., 6.]] * mA,
+         [[3., 0.],
+          [0., 4.]] * ohm)
 
     Args:
         fun: Function whose Jacobian is to be computed.

--- a/brainunit/autograd/_vector_grad.py
+++ b/brainunit/autograd/_vector_grad.py
@@ -40,8 +40,35 @@ def vector_grad(
     unit_aware: bool = True,
 ):
     """
-     Compute the gradient of a vector with respect to the input.
-     """
+    Unit-aware compute the gradient of a vector with respect to the input.
+
+    Example::
+        >>> import jax.numpy as jnp
+        >>> import brainunit as u
+        >>> def simple_function(x):
+        ...    return x ** 2
+        >>> vector_grad_fn = u.autograd.vector_grad(simple_function)
+        >>> vector_grad_fn(jnp.array([3.0, 4.0]) * u.ms)
+        [6.0, 8.0] * ms
+        >>> vector_grad_fn = u.autograd.vector_grad(simple_function, return_value=True)
+        >>> grad, value = vector_grad_fn(jnp.array([3.0, 4.0]) * u.ms)
+        >>> grad
+        [6.0, 8.0] * ms
+        >>> value
+        [9.0, 16.0] * ms ** 2
+
+    Args:
+        fun: A Python callable that computes a scalar loss given arguments.
+        argnums: Optional, an integer or a tuple of integers. The argument number(s) to differentiate with respect to.
+        return_value: Optional, bool. Whether to return the value of the function.
+        has_aux: Optional, whether `fun` returns auxiliary data.
+        unit_aware: Optional, whether to enable unit-aware computation.
+
+    Returns:
+        A function that computes the gradient of `fun` with respect to
+        the argument(s) indicated by `argnums`.
+    """
+
     _check_callable(func)
 
     @wraps(func)


### PR DESCRIPTION
This pull request adds example usage to several functions in the `brainunit/autograd` module to improve documentation and clarify how to use these functions with physical unit-aware computations. The most important changes include the addition of examples for the `hessian`, `jacrev`, `jacfwd`, and `vector_grad` functions.

Documentation improvements:

* [`brainunit/autograd/_hessian.py`](diffhunk://#diff-eac0e8cf925cdc4f7da0408c8dd69cbaf3b8a68e94ef0b883a12e3b758b1e62fR38-R51): Added example usage for the `hessian` function to demonstrate how to compute the Hessian of a function with physical units.
* [`brainunit/autograd/_jacobian.py`](diffhunk://#diff-6bb63bbe1dbc675dc6b49cc714fdc2c7a2ca51f37f3cb39b054488233a604a5bR52-R70): Added example usage for the `jacrev` function to show how to compute the Jacobian of a function with physical units.
* [`brainunit/autograd/_jacobian.py`](diffhunk://#diff-6bb63bbe1dbc675dc6b49cc714fdc2c7a2ca51f37f3cb39b054488233a604a5bR176-R194): Added example usage for the `jacfwd` function to illustrate how to compute the forward-mode Jacobian of a function with physical units.
* [`brainunit/autograd/_vector_grad.py`](diffhunk://#diff-17e38b7b1f5fdec379563862d2eef0b191a30b90640f91da74bb8f06953c90ecL43-R71): Added example usage for the `vector_grad` function to explain how to compute the gradient of a vector with respect to the input and handle physical units.

## Summary by Sourcery

Documentation:
- Document how to use the `hessian`, `jacrev`, `jacfwd`, and `vector_grad` functions with physical unit-aware computations.