### PR TITLE
[doc] Update autograd docstring

### DIFF
--- a/brainunit/autograd/_hessian.py
+++ b/brainunit/autograd/_hessian.py
@@ -35,6 +35,20 @@ def hessian(
     Physical unit-aware version of `jax.hessian <https://jax.readthedocs.io/en/latest/_autosummary/jax.hessian.html>`_,
     computing Hessian of ``fun`` as a dense array.
 
+    Example::
+        >>> import jax.numpy as jnp
+        >>> import brainunit as u
+        >>> def scalar_function1(x):
+        ...    return x ** 2 + 3 * x * u.ms + 2 * u.msecond2
+        >>> hess_fn = u.autograd.hessian(scalar_function1)
+        >>> hess_fn(jnp.array(1.0) * u.ms)
+        [2]
+        >>> def scalar_function2(x):
+        ...     return x ** 3 + 3 * x * u.msecond2 + 2 * u.msecond3
+        >>> hess_fn = u.autograd.hessian(scalar_function2)
+        >>> hess_fn(jnp.array(1.0) * u.ms)
+        [6] * ms
+
     Args:
       fun: Function whose Hessian is to be computed.  Its arguments at positions
         specified by ``argnums`` should be arrays, scalars, or standard Python

--- a/brainunit/autograd/_hessian.py
+++ b/brainunit/autograd/_hessian.py
@@ -96,7 +96,7 @@ def hessian(
 
     In particular, an array is produced (with no pytrees involved) when the
     function input ``x`` and output ``fun(x)`` are each a single array, as in the
-    ``g`` example above. If ``fun(x)`` has shape ``(out1, out2, ...)`` and ``x``
+    ``dict_function`` example above. If ``fun(x)`` has shape ``(out1, out2, ...)`` and ``x``
     has shape ``(in1, in2, ...)`` then ``brainunit.autograd.hessian(fun)(x)`` has shape
     ``(out1, out2, ..., in1, in2, ..., in1, in2, ...)``. To flatten pytrees into
     1D vectors, consider using :py:func:`jax.flatten_util.flatten_pytree`.

--- a/brainunit/autograd/_hessian.py
+++ b/brainunit/autograd/_hessian.py
@@ -86,7 +86,7 @@ def hessian(
 
     Thus each leaf in the tree structure of ``brainunit.autograd.hessian(fun)(x)`` corresponds to
     a leaf of ``fun(x)`` and a pair of leaves of ``x``. For each leaf in
-    ``jax.hessian(fun)(x)``, if the corresponding array leaf of ``fun(x)`` has
+    ``brainunit.autograd.hessian(fun)(x)``, if the corresponding array leaf of ``fun(x)`` has
     shape ``(out_1, out_2, ...)`` and the corresponding array leaves of ``x`` have
     shape ``(in_1_1, in_1_2, ...)`` and ``(in_2_1, in_2_2, ...)`` respectively,
     then the Hessian leaf has shape ``(out_1, out_2, ..., in_1_1, in_1_2, ...,
@@ -97,7 +97,7 @@ def hessian(
     In particular, an array is produced (with no pytrees involved) when the
     function input ``x`` and output ``fun(x)`` are each a single array, as in the
     ``g`` example above. If ``fun(x)`` has shape ``(out1, out2, ...)`` and ``x``
-    has shape ``(in1, in2, ...)`` then ``jax.hessian(fun)(x)`` has shape
+    has shape ``(in1, in2, ...)`` then ``brainunit.autograd.hessian(fun)(x)`` has shape
     ``(out1, out2, ..., in1, in2, ..., in1, in2, ...)``. To flatten pytrees into
     1D vectors, consider using :py:func:`jax.flatten_util.flatten_pytree`.
     """

--- a/brainunit/autograd/_hessian.py
+++ b/brainunit/autograd/_hessian.py
@@ -35,20 +35,6 @@ def hessian(
     Physical unit-aware version of `jax.hessian <https://jax.readthedocs.io/en/latest/_autosummary/jax.hessian.html>`_,
     computing Hessian of ``fun`` as a dense array.
 
-    Example::
-        >>> import jax.numpy as jnp
-        >>> import brainunit as u
-        >>> def scalar_function1(x):
-        ...    return x ** 2 + 3 * x * u.ms + 2 * u.msecond2
-        >>> hess_fn = u.autograd.hessian(scalar_function1)
-        >>> hess_fn(jnp.array(1.0) * u.ms)
-        [2]
-        >>> def scalar_function2(x):
-        ...     return x ** 3 + 3 * x * u.msecond2 + 2 * u.msecond3
-        >>> hess_fn = u.autograd.hessian(scalar_function2)
-        >>> hess_fn(jnp.array(1.0) * u.ms)
-        [6] * ms
-
     Args:
       fun: Function whose Hessian is to be computed.  Its arguments at positions
         specified by ``argnums`` should be arrays, scalars, or standard Python
@@ -65,6 +51,55 @@ def hessian(
     Returns:
       A function with the same arguments as ``fun``, that evaluates the Hessian of
       ``fun``.
+
+    >>> import jax.numpy as jnp
+    >>> import brainunit as u
+    >>> def scalar_function1(x):
+    ...    return x ** 2 + 3 * x * u.ms + 2 * u.msecond2
+    >>> hess_fn = u.autograd.hessian(scalar_function1)
+    >>> hess_fn(jnp.array(1.0) * u.ms)
+    [2]
+
+    >>> import jax.numpy as jnp
+    >>> import brainunit as u
+    >>> def scalar_function2(x):
+    ...     return x ** 3 + 3 * x * u.msecond2 + 2 * u.msecond3
+    >>> hess_fn = u.autograd.hessian(scalar_function2)
+    >>> hess_fn(jnp.array(1.0) * u.ms)
+    [6] * ms
+
+    `hessian` is a generalization of the usual definition of the Hessian
+    that supports nested Python containers (i.e. pytrees) as inputs and outputs.
+    The tree structure of ``brainunit.autograd.hessian(fun)(x)`` is given by forming a tree
+    product of the structure of ``fun(x)`` with a tree product of two copies of
+    the structure of ``x``. A tree product of two tree structures is formed by
+    replacing each leaf of the first tree with a copy of the second. For example:
+
+    >>> import jax.numpy as jnp
+    >>> import brainunit as u
+    >>> def dict_function(x):
+    ...     return {'z': x['a'] ** 3 + x['b'] ** 3}
+    >>> x = {'a': jnp.array(1.0) * u.ms, 'b': jnp.array(2.0) * u.ms}
+    >>> u.autograd.hessian(dict_function)(x)
+    {'z': {'a': {'a': 6. * msecond, 'b': 0. * msecond},
+     'b': {'a': 0. * msecond, 'b': 12. * msecond}}}
+
+    Thus each leaf in the tree structure of ``brainunit.autograd.hessian(fun)(x)`` corresponds to
+    a leaf of ``fun(x)`` and a pair of leaves of ``x``. For each leaf in
+    ``jax.hessian(fun)(x)``, if the corresponding array leaf of ``fun(x)`` has
+    shape ``(out_1, out_2, ...)`` and the corresponding array leaves of ``x`` have
+    shape ``(in_1_1, in_1_2, ...)`` and ``(in_2_1, in_2_2, ...)`` respectively,
+    then the Hessian leaf has shape ``(out_1, out_2, ..., in_1_1, in_1_2, ...,
+    in_2_1, in_2_2, ...)``. In other words, the Python tree structure represents
+    the block structure of the Hessian, with blocks determined by the input and
+    output pytrees.
+
+    In particular, an array is produced (with no pytrees involved) when the
+    function input ``x`` and output ``fun(x)`` are each a single array, as in the
+    ``g`` example above. If ``fun(x)`` has shape ``(out1, out2, ...)`` and ``x``
+    has shape ``(in1, in2, ...)`` then ``jax.hessian(fun)(x)`` has shape
+    ``(out1, out2, ..., in1, in2, ..., in1, in2, ...)``. To flatten pytrees into
+    1D vectors, consider using :py:func:`jax.flatten_util.flatten_pytree`.
     """
     _check_callable(fun)
 

--- a/brainunit/autograd/_hessian.py
+++ b/brainunit/autograd/_hessian.py
@@ -35,20 +35,6 @@ def hessian(
     Physical unit-aware version of `jax.hessian <https://jax.readthedocs.io/en/latest/_autosummary/jax.hessian.html>`_,
     computing Hessian of ``fun`` as a dense array.
 
-    Example::
-        >>> import jax.numpy as jnp
-        >>> import brainunit as u
-        >>> def scalar_function1(x):
-        ...    return x ** 2 + 3 * x * u.ms + 2 * u.msecond2
-        >>> hess_fn = u.autograd.hessian(scalar_function1)
-        >>> hess_fn(jnp.array(1.0) * u.ms)
-        [2]
-        >>> def scalar_function2(x):
-        ...     return x ** 3 + 3 * x * u.msecond2 + 2 * u.msecond3
-        >>> hess_fn = u.autograd.hessian(scalar_function2)
-        >>> hess_fn(jnp.array(1.0) * u.ms)
-        [6] * ms
-
     Args:
       fun: Function whose Hessian is to be computed.  Its arguments at positions
         specified by ``argnums`` should be arrays, scalars, or standard Python

--- a/brainunit/autograd/_jacobian.py
+++ b/brainunit/autograd/_jacobian.py
@@ -49,6 +49,25 @@ def jacrev(
     """
     Physical unit-aware version of `jax.jacrev <https://jax.readthedocs.io/en/latest/_autosummary/jax.jacrev.html>`_.
 
+    Example::
+            >>> import jax.numpy as jnp
+            >>> import brainunit as u
+            >>> def simple_function1(x):
+            ...    return x ** 2
+            >>> jac_fn = u.autograd.jacrev(simple_function)
+            >>> jac_fn(jnp.array(3.0) * u.ms)
+            6.0 * ms
+            >>> def simple_function2(x, y):
+            ...    return x * y
+            >>> jac_fn = u.autograd.jacrev(simple_function2, argnums=(0, 1))
+            >>> x = jnp.array([3.0, 4.0]) * u.ohm
+            >>> y = jnp.array([5.0, 6.0]) * u.mA
+            >>> jac_fn(x, y)
+            ([[5., 0.],
+              [0., 6.]] * mA,
+             [[3., 0.],
+              [0., 4.]] * ohm)
+
     Args:
         fun: Function whose Jacobian is to be computed.
         argnums: Optional, integer or sequence of integers. Specifies which
@@ -153,6 +172,25 @@ def jacfwd(
 ) -> Callable:
     """
     Physical unit-aware version of `jax.jacfwd <https://jax.readthedocs.io/en/latest/_autosummary/jax.jacfwd.html>`_.
+
+    Example::
+        >>> import jax.numpy as jnp
+        >>> import brainunit as u
+        >>> def simple_function(x):
+        ...    return x ** 2
+        >>> jac_fn = u.autograd.jacfwd(simple_function)
+        >>> jac_fn(jnp.array(3.0) * u.ms)
+        6.0 * ms
+        >>> def simple_function(x, y):
+        ...    return x * y
+        >>> jac_fn = u.autograd.jacfwd(simple_function, argnums=(0, 1))
+        >>> x = jnp.array([3.0, 4.0]) * u.ohm
+        >>> y = jnp.array([5.0, 6.0]) * u.mA
+        >>> jac_fn(x, y)
+        ([[5., 0.],
+          [0., 6.]] * mA,
+         [[3., 0.],
+          [0., 4.]] * ohm)
 
     Args:
         fun: Function whose Jacobian is to be computed.

--- a/brainunit/autograd/_jacobian.py
+++ b/brainunit/autograd/_jacobian.py
@@ -130,7 +130,7 @@ def jacrev(
 
     In particular, an array is produced (with no pytrees involved) when the
     function input ``x`` and output ``fun(x)`` are each a single array, as in the
-    ``g`` example above. If ``fun(x)`` has shape ``(out1, out2, ...)`` and ``x``
+    ``simple_function`` example above. If ``fun(x)`` has shape ``(out1, out2, ...)`` and ``x``
     has shape ``(in1, in2, ...)`` then ``brainunit.autograd.jacrec(fun)(x)`` has shape
     ``(out1, out2, ..., in1, in2, ..., in1, in2, ...)``. To flatten pytrees into
     1D vectors, consider using :py:func:`jax.flatten_util.flatten_pytree`.
@@ -320,7 +320,7 @@ def jacfwd(
 
     In particular, an array is produced (with no pytrees involved) when the
     function input ``x`` and output ``fun(x)`` are each a single array, as in the
-    ``g`` example above. If ``fun(x)`` has shape ``(out1, out2, ...)`` and ``x``
+    ``simple_function`` example above. If ``fun(x)`` has shape ``(out1, out2, ...)`` and ``x``
     has shape ``(in1, in2, ...)`` then ``brainunit.autograd.jacrec(fun)(x)`` has shape
     ``(out1, out2, ..., in1, in2, ..., in1, in2, ...)``. To flatten pytrees into
     1D vectors, consider using :py:func:`jax.flatten_util.flatten_pytree`.

--- a/brainunit/autograd/_jacobian.py
+++ b/brainunit/autograd/_jacobian.py
@@ -49,25 +49,6 @@ def jacrev(
     """
     Physical unit-aware version of `jax.jacrev <https://jax.readthedocs.io/en/latest/_autosummary/jax.jacrev.html>`_.
 
-    Example::
-            >>> import jax.numpy as jnp
-            >>> import brainunit as u
-            >>> def simple_function1(x):
-            ...    return x ** 2
-            >>> jac_fn = u.autograd.jacrev(simple_function)
-            >>> jac_fn(jnp.array(3.0) * u.ms)
-            6.0 * ms
-            >>> def simple_function2(x, y):
-            ...    return x * y
-            >>> jac_fn = u.autograd.jacrev(simple_function2, argnums=(0, 1))
-            >>> x = jnp.array([3.0, 4.0]) * u.ohm
-            >>> y = jnp.array([5.0, 6.0]) * u.mA
-            >>> jac_fn(x, y)
-            ([[5., 0.],
-              [0., 6.]] * mA,
-             [[3., 0.],
-              [0., 4.]] * ohm)
-
     Args:
         fun: Function whose Jacobian is to be computed.
         argnums: Optional, integer or sequence of integers. Specifies which
@@ -80,6 +61,79 @@ def jacrev(
 
     Returns:
         A function that computes the Jacobian of ``fun`` through reverse-mode automatic differentiation.
+
+    >>> import jax.numpy as jnp
+    >>> import brainunit as u
+    >>> def simple_function1(x):
+    ...    return x ** 2
+    >>> jac_fn = u.autograd.jacrev(simple_function)
+    >>> jac_fn(jnp.array(3.0) * u.ms)
+    6.0 * ms
+
+    >>> import jax.numpy as jnp
+    >>> import brainunit as u
+    >>> def simple_function2(x, y):
+    ...    return x * y
+    >>> jac_fn = u.autograd.jacrev(simple_function2, argnums=(0, 1))
+    >>> x = jnp.array([3.0, 4.0]) * u.ohm
+    >>> y = jnp.array([5.0, 6.0]) * u.mA
+    >>> jac_fn(x, y)
+    ([[5., 0.],
+      [0., 6.]] * mA,
+     [[3., 0.],
+      [0., 4.]] * ohm)
+
+    `jacrev` is a generalization of the usual definition of the JacRev(Jacobian Reverse Mode).
+    that supports nested Python containers (i.e. pytrees) as inputs and outputs.
+    The tree structure of ``brainunit.autograd.jacrev(fun)(x)`` is given by forming a tree
+    product of the structure of ``fun(x)`` with a tree product of two copies of
+    the structure of ``x``. A tree product of two tree structures is formed by
+    replacing each leaf of the first tree with a copy of the second. For example:
+
+    >>> import jax.numpy as jnp
+    >>> import brainunit as u
+    >>> def dict_function(inputs):
+    ...    o1 = inputs['x'] * inputs['y']
+    ...    o2 = inputs['x'] * inputs['z']
+    ...    r = {'o1': o1, 'o2': o2}
+    ...    return r, r
+    >>> jac_fn = u.autograd.jacrev(dict_function, has_aux=True)
+    >>> x = jnp.array([3.0, 4.0]) * u.ohm
+    >>> y = jnp.array([5.0, 6.0]) * u.mA
+    >>> z = jnp.array([7.0, 8.0]) * u.siemens
+    >>> inp = {'x': x, 'y': y, 'z': z}
+    >>> jac_fn(inp)
+    ({'o1': {'x': ArrayImpl([[5., 0.],
+                  [0., 6.]], dtype=float32) * mampere,
+       'y': ArrayImpl([[3., 0.],
+                  [0., 4.]], dtype=float32) * ohm,
+       'z': ArrayImpl([[0., 0.],
+                  [0., 0.]], dtype=float32) * mvolt / siemens},
+      'o2': {'x': ArrayImpl([[7., 0.],
+                  [0., 8.]], dtype=float32) * siemens,
+       'y': ArrayImpl([[0., 0.],
+                  [0., 0.]], dtype=float32) * 10.0^3 * amp ** -1,
+       'z': ArrayImpl([[3., 0.],
+                  [0., 4.]], dtype=float32) * ohm}},
+     {'o1': ArrayImpl([15., 24.], dtype=float32) * mvolt,
+      'o2': Array([21., 32.], dtype=float32)})
+
+    Thus each leaf in the tree structure of ``brainunit.autograd.jacrev(fun)(x)`` corresponds to
+    a leaf of ``fun(x)`` and a pair of leaves of ``x``. For each leaf in
+    ``brainunit.autograd.jacrev(fun)(x)``, if the corresponding array leaf of ``fun(x)`` has
+    shape ``(out_1, out_2, ...)`` and the corresponding array leaves of ``x`` have
+    shape ``(in_1_1, in_1_2, ...)`` and ``(in_2_1, in_2_2, ...)`` respectively,
+    then the JacRev leaf has shape ``(out_1, out_2, ..., in_1_1, in_1_2, ...,
+    in_2_1, in_2_2, ...)``. In other words, the Python tree structure represents
+    the block structure of the Hessian, with blocks determined by the input and
+    output pytrees.
+
+    In particular, an array is produced (with no pytrees involved) when the
+    function input ``x`` and output ``fun(x)`` are each a single array, as in the
+    ``g`` example above. If ``fun(x)`` has shape ``(out1, out2, ...)`` and ``x``
+    has shape ``(in1, in2, ...)`` then ``brainunit.autograd.jacrec(fun)(x)`` has shape
+    ``(out1, out2, ..., in1, in2, ..., in1, in2, ...)``. To flatten pytrees into
+    1D vectors, consider using :py:func:`jax.flatten_util.flatten_pytree`.
     """
     _check_callable(fun)
 
@@ -154,6 +208,19 @@ def jacobian(
 ) -> Callable:
     """
     Alias of :func:`jacrev`.
+
+    Args:
+        fun: Function whose Jacobian is to be computed.
+        argnums: Optional, integer or sequence of integers. Specifies which
+            positional argument(s) to differentiate with respect to (default ``0``).
+        has_aux: Optional, bool. Indicates whether ``fun`` returns a pair where the
+            first element is considered the output of the mathematical function to be
+            differentiated and the second element is auxiliary data. Default False.
+        holomorphic: Optional, bool. Indicates whether ``fun`` is promised to be holomorphic. Default False.
+        allow_int: Optional, bool. Indicates whether integer arguments are allowed. Default False.
+
+    Returns:
+        A function that computes the Jacobian of ``fun`` through reverse-mode automatic differentiation.
     """
     return jacrev(
         fun,
@@ -173,25 +240,6 @@ def jacfwd(
     """
     Physical unit-aware version of `jax.jacfwd <https://jax.readthedocs.io/en/latest/_autosummary/jax.jacfwd.html>`_.
 
-    Example::
-        >>> import jax.numpy as jnp
-        >>> import brainunit as u
-        >>> def simple_function(x):
-        ...    return x ** 2
-        >>> jac_fn = u.autograd.jacfwd(simple_function)
-        >>> jac_fn(jnp.array(3.0) * u.ms)
-        6.0 * ms
-        >>> def simple_function(x, y):
-        ...    return x * y
-        >>> jac_fn = u.autograd.jacfwd(simple_function, argnums=(0, 1))
-        >>> x = jnp.array([3.0, 4.0]) * u.ohm
-        >>> y = jnp.array([5.0, 6.0]) * u.mA
-        >>> jac_fn(x, y)
-        ([[5., 0.],
-          [0., 6.]] * mA,
-         [[3., 0.],
-          [0., 4.]] * ohm)
-
     Args:
         fun: Function whose Jacobian is to be computed.
         argnums: Optional, integer or sequence of integers. Specifies which
@@ -203,6 +251,79 @@ def jacfwd(
 
     Returns:
         A function that computes the Jacobian of ``fun`` through forward-mode automatic differentiation.
+
+    >>> import jax.numpy as jnp
+    >>> import brainunit as u
+    >>> def simple_function(x):
+    ...    return x ** 2
+    >>> jac_fn = u.autograd.jacfwd(simple_function)
+    >>> jac_fn(jnp.array(3.0) * u.ms)
+    6.0 * ms
+
+    >>> import jax.numpy as jnp
+    >>> import brainunit as u
+    >>> def simple_function(x, y):
+    ...    return x * y
+    >>> jac_fn = u.autograd.jacfwd(simple_function, argnums=(0, 1))
+    >>> x = jnp.array([3.0, 4.0]) * u.ohm
+    >>> y = jnp.array([5.0, 6.0]) * u.mA
+    >>> jac_fn(x, y)
+    ([[5., 0.],
+      [0., 6.]] * mA,
+     [[3., 0.],
+      [0., 4.]] * ohm)
+
+    `jacfwd` is a generalization of the usual definition of the JacFwd(Jacobian Reverse Mode).
+    that supports nested Python containers (i.e. pytrees) as inputs and outputs.
+    The tree structure of ``brainunit.autograd.jacfwd(fun)(x)`` is given by forming a tree
+    product of the structure of ``fun(x)`` with a tree product of two copies of
+    the structure of ``x``. A tree product of two tree structures is formed by
+    replacing each leaf of the first tree with a copy of the second. For example:
+
+    >>> import jax.numpy as jnp
+    >>> import brainunit as u
+    >>> def dict_function(inputs):
+    ...    o1 = inputs['x'] * inputs['y']
+    ...    o2 = inputs['x'] * inputs['z']
+    ...    r = {'o1': o1, 'o2': o2}
+    ...    return r, r
+    >>> jac_fn = u.autograd.jacfwd(dict_function, has_aux=True)
+    >>> x = jnp.array([3.0, 4.0]) * u.ohm
+    >>> y = jnp.array([5.0, 6.0]) * u.mA
+    >>> z = jnp.array([7.0, 8.0]) * u.siemens
+    >>> inp = {'x': x, 'y': y, 'z': z}
+    >>> jac_fn(inp)
+    ({'o1': {'x': ArrayImpl([[5., 0.],
+                  [0., 6.]], dtype=float32) * mampere,
+       'y': ArrayImpl([[3., 0.],
+                  [0., 4.]], dtype=float32) * ohm,
+       'z': ArrayImpl([[0., 0.],
+                  [0., 0.]], dtype=float32) * mvolt / siemens},
+      'o2': {'x': ArrayImpl([[7., 0.],
+                  [0., 8.]], dtype=float32) * siemens,
+       'y': ArrayImpl([[0., 0.],
+                  [0., 0.]], dtype=float32) * 10.0^3 * amp ** -1,
+       'z': ArrayImpl([[3., 0.],
+                  [0., 4.]], dtype=float32) * ohm}},
+     {'o1': ArrayImpl([15., 24.], dtype=float32) * mvolt,
+      'o2': Array([21., 32.], dtype=float32)})
+
+    Thus each leaf in the tree structure of ``brainunit.autograd.jacfwd(fun)(x)`` corresponds to
+    a leaf of ``fun(x)`` and a pair of leaves of ``x``. For each leaf in
+    ``brainunit.autograd.jacfwd(fun)(x)``, if the corresponding array leaf of ``fun(x)`` has
+    shape ``(out_1, out_2, ...)`` and the corresponding array leaves of ``x`` have
+    shape ``(in_1_1, in_1_2, ...)`` and ``(in_2_1, in_2_2, ...)`` respectively,
+    then the JacFwd leaf has shape ``(out_1, out_2, ..., in_1_1, in_1_2, ...,
+    in_2_1, in_2_2, ...)``. In other words, the Python tree structure represents
+    the block structure of the Hessian, with blocks determined by the input and
+    output pytrees.
+
+    In particular, an array is produced (with no pytrees involved) when the
+    function input ``x`` and output ``fun(x)`` are each a single array, as in the
+    ``g`` example above. If ``fun(x)`` has shape ``(out1, out2, ...)`` and ``x``
+    has shape ``(in1, in2, ...)`` then ``brainunit.autograd.jacrec(fun)(x)`` has shape
+    ``(out1, out2, ..., in1, in2, ..., in1, in2, ...)``. To flatten pytrees into
+    1D vectors, consider using :py:func:`jax.flatten_util.flatten_pytree`.
     """
     _check_callable(fun)
     argnums = _ensure_index(argnums)

--- a/brainunit/autograd/_jacobian.py
+++ b/brainunit/autograd/_jacobian.py
@@ -49,25 +49,6 @@ def jacrev(
     """
     Physical unit-aware version of `jax.jacrev <https://jax.readthedocs.io/en/latest/_autosummary/jax.jacrev.html>`_.
 
-    Example::
-            >>> import jax.numpy as jnp
-            >>> import brainunit as u
-            >>> def simple_function1(x):
-            ...    return x ** 2
-            >>> jac_fn = u.autograd.jacrev(simple_function)
-            >>> jac_fn(jnp.array(3.0) * u.ms)
-            6.0 * ms
-            >>> def simple_function2(x, y):
-            ...    return x * y
-            >>> jac_fn = u.autograd.jacrev(simple_function2, argnums=(0, 1))
-            >>> x = jnp.array([3.0, 4.0]) * u.ohm
-            >>> y = jnp.array([5.0, 6.0]) * u.mA
-            >>> jac_fn(x, y)
-            ([[5., 0.],
-              [0., 6.]] * mA,
-             [[3., 0.],
-              [0., 4.]] * ohm)
-
     Args:
         fun: Function whose Jacobian is to be computed.
         argnums: Optional, integer or sequence of integers. Specifies which
@@ -258,25 +239,6 @@ def jacfwd(
 ) -> Callable:
     """
     Physical unit-aware version of `jax.jacfwd <https://jax.readthedocs.io/en/latest/_autosummary/jax.jacfwd.html>`_.
-
-    Example::
-        >>> import jax.numpy as jnp
-        >>> import brainunit as u
-        >>> def simple_function(x):
-        ...    return x ** 2
-        >>> jac_fn = u.autograd.jacfwd(simple_function)
-        >>> jac_fn(jnp.array(3.0) * u.ms)
-        6.0 * ms
-        >>> def simple_function(x, y):
-        ...    return x * y
-        >>> jac_fn = u.autograd.jacfwd(simple_function, argnums=(0, 1))
-        >>> x = jnp.array([3.0, 4.0]) * u.ohm
-        >>> y = jnp.array([5.0, 6.0]) * u.mA
-        >>> jac_fn(x, y)
-        ([[5., 0.],
-          [0., 6.]] * mA,
-         [[3., 0.],
-          [0., 4.]] * ohm)
 
     Args:
         fun: Function whose Jacobian is to be computed.

--- a/brainunit/autograd/_jacobian.py
+++ b/brainunit/autograd/_jacobian.py
@@ -66,7 +66,7 @@ def jacrev(
     >>> import brainunit as u
     >>> def simple_function1(x):
     ...    return x ** 2
-    >>> jac_fn = u.autograd.jacrev(simple_function)
+>>> jac_fn = u.autograd.jacrev(simple_function1)
     >>> jac_fn(jnp.array(3.0) * u.ms)
     6.0 * ms
 

--- a/brainunit/autograd/_vector_grad.py
+++ b/brainunit/autograd/_vector_grad.py
@@ -40,8 +40,35 @@ def vector_grad(
     unit_aware: bool = True,
 ):
     """
-     Compute the gradient of a vector with respect to the input.
-     """
+    Unit-aware compute the gradient of a vector with respect to the input.
+
+    Example::
+        >>> import jax.numpy as jnp
+        >>> import brainunit as u
+        >>> def simple_function(x):
+        ...    return x ** 2
+        >>> vector_grad_fn = u.autograd.vector_grad(simple_function)
+        >>> vector_grad_fn(jnp.array([3.0, 4.0]) * u.ms)
+        [6.0, 8.0] * ms
+        >>> vector_grad_fn = u.autograd.vector_grad(simple_function, return_value=True)
+        >>> grad, value = vector_grad_fn(jnp.array([3.0, 4.0]) * u.ms)
+        >>> grad
+        [6.0, 8.0] * ms
+        >>> value
+        [9.0, 16.0] * ms ** 2
+
+    Args:
+        fun: A Python callable that computes a scalar loss given arguments.
+        argnums: Optional, an integer or a tuple of integers. The argument number(s) to differentiate with respect to.
+        return_value: Optional, bool. Whether to return the value of the function.
+        has_aux: Optional, whether `fun` returns auxiliary data.
+        unit_aware: Optional, whether to enable unit-aware computation.
+
+    Returns:
+        A function that computes the gradient of `fun` with respect to
+        the argument(s) indicated by `argnums`.
+    """
+
     _check_callable(func)
 
     @wraps(func)

--- a/brainunit/autograd/_vector_grad.py
+++ b/brainunit/autograd/_vector_grad.py
@@ -42,21 +42,6 @@ def vector_grad(
     """
     Unit-aware compute the gradient of a vector with respect to the input.
 
-    Example::
-        >>> import jax.numpy as jnp
-        >>> import brainunit as u
-        >>> def simple_function(x):
-        ...    return x ** 2
-        >>> vector_grad_fn = u.autograd.vector_grad(simple_function)
-        >>> vector_grad_fn(jnp.array([3.0, 4.0]) * u.ms)
-        [6.0, 8.0] * ms
-        >>> vector_grad_fn = u.autograd.vector_grad(simple_function, return_value=True)
-        >>> grad, value = vector_grad_fn(jnp.array([3.0, 4.0]) * u.ms)
-        >>> grad
-        [6.0, 8.0] * ms
-        >>> value
-        [9.0, 16.0] * ms ** 2
-
     Args:
         fun: A Python callable that computes a scalar loss given arguments.
         argnums: Optional, an integer or a tuple of integers. The argument number(s) to differentiate with respect to.
@@ -67,6 +52,25 @@ def vector_grad(
     Returns:
         A function that computes the gradient of `fun` with respect to
         the argument(s) indicated by `argnums`.
+
+    >>> import jax.numpy as jnp
+    >>> import brainunit as u
+    >>> def simple_function(x):
+    ...    return x ** 2
+    >>> vector_grad_fn = u.autograd.vector_grad(simple_function)
+    >>> vector_grad_fn(jnp.array([3.0, 4.0]) * u.ms)
+    [6.0, 8.0] * ms
+
+    >>> import jax.numpy as jnp
+    >>> import brainunit as u
+    >>> def simple_function(x):
+    ...    return x ** 2
+    >>> vector_grad_fn = u.autograd.vector_grad(simple_function, return_value=True)
+    >>> grad, value = vector_grad_fn(jnp.array([3.0, 4.0]) * u.ms)
+    >>> grad
+    [6.0, 8.0] * ms
+    >>> value
+    [9.0, 16.0] * ms ** 2
     """
 
     _check_callable(func)


### PR DESCRIPTION
This pull request includes significant enhancements to the `brainunit` library's autograd functionality, specifically adding detailed examples and explanations to the docstrings of several key functions. These additions aim to improve user understanding and usability of the library's automatic differentiation features.

Enhancements to docstrings with examples and explanations:

* [`brainunit/autograd/_hessian.py`](diffhunk://#diff-eac0e8cf925cdc4f7da0408c8dd69cbaf3b8a68e94ef0b883a12e3b758b1e62fR54-R102): Added comprehensive examples and detailed explanations to the `hessian` function's docstring, illustrating usage with scalar and dictionary functions.
* [`brainunit/autograd/_jacobian.py`](diffhunk://#diff-6bb63bbe1dbc675dc6b49cc714fdc2c7a2ca51f37f3cb39b054488233a604a5bR64-R136): Enhanced the `jacrev` function's docstring with examples and explanations, including usage with simple and dictionary functions.
* [`brainunit/autograd/_jacobian.py`](diffhunk://#diff-6bb63bbe1dbc675dc6b49cc714fdc2c7a2ca51f37f3cb39b054488233a604a5bR211-R223): Added detailed argument descriptions and return information to the `jacobian` function's docstring.
* [`brainunit/autograd/_jacobian.py`](diffhunk://#diff-6bb63bbe1dbc675dc6b49cc714fdc2c7a2ca51f37f3cb39b054488233a604a5bR254-R326): Improved the `jacfwd` function's docstring by including examples and detailed explanations, similar to the `jacrev` function.
* [`brainunit/autograd/_vector_grad.py`](diffhunk://#diff-17e38b7b1f5fdec379563862d2eef0b191a30b90640f91da74bb8f06953c90ecL43-R75): Enhanced the `vector_grad` function's docstring with examples, argument descriptions, and return information to clarify its usage.

## Summary by Sourcery

Documentation:
- Add examples and explanations to the docstrings of several autograd functions, including `hessian`, `jacrev`, `jacobian`, `jacfwd`, and `vector_grad`, to improve user understanding.