### PR TITLE
`Quantity` initialization does not call jax.numpy.asarray when mantissa is a python number

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
 
     steps:
       - name: Cancel Previous Runs
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
 
     steps:
       - name: Cancel Previous Runs
@@ -88,7 +88,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
 
     steps:
       - name: Cancel Previous Runs

--- a/.gitignore
+++ b/.gitignore
@@ -227,3 +227,4 @@ cython_debug/
 /docs/apis/changelog.md
 /dist-hist/
 /dist-hist/
+/examples/

--- a/brainunit/_base.py
+++ b/brainunit/_base.py
@@ -3632,7 +3632,11 @@ class Quantity:
         If ``a.ndim`` is 0, then since the depth of the nested list is 0, it will
         not be a list at all, but a simple Python scalar.
         """
-        return _replace_with_array(self.mantissa.tolist(), self.unit)
+        if isinstance(self.mantissa, numbers.Number):
+            list_mantissa = self.mantissa
+        else:
+            list_mantissa = self.mantissa.tolist()
+        return _replace_with_array(list_mantissa, self.unit)
 
     def transpose(self, *axes) -> 'Quantity':
         """Returns a view of the array with axes transposed.
@@ -4055,7 +4059,7 @@ class _IndexUpdateRef:
         arguments ``indices_are_sorted`` and ``unique_indices`` to be passed.
         """
         if fill_value is not None:
-            fill_value = Quantity(fill_value).in_unit(self.unit).mantissa.item()
+            fill_value = Quantity(fill_value).in_unit(self.unit).mantissa
         return Quantity(
             self.mantissa_at[self.index].get(
                 indices_are_sorted=indices_are_sorted,

--- a/brainunit/_base.py
+++ b/brainunit/_base.py
@@ -2187,7 +2187,8 @@ class Quantity:
                 # skip 'asarray' if dtype is not provided
 
             elif isinstance(mantissa, (jnp.number, numbers.Number)):
-                mantissa = jnp.array(mantissa, dtype=dtype)
+                # mantissa = jnp.array(mantissa, dtype=dtype)
+                mantissa = mantissa
 
             else:
                 mantissa = mantissa

--- a/brainunit/_base_test.py
+++ b/brainunit/_base_test.py
@@ -107,8 +107,8 @@ class TestUnit(unittest.TestCase):
         assert_equal(str(u.kmeter / u.meter), 'Unit(10.0^3)')
 
     def test_unit_with_factor(self):
-        self.assertTrue(1. * u.eV / u.joule == 1.6021766e-19)
-        self.assertTrue(1. * u.joule / u.eV == 6.241509074460762e18)
+        self.assertTrue(u.math.isclose(1. * u.eV / u.joule, 1.6021766e-19))
+        self.assertTrue(u.math.isclose(1. * u.joule / u.eV, 6.241509074460762e18))
 
 
 class TestQuantity(unittest.TestCase):
@@ -261,10 +261,10 @@ class TestQuantity(unittest.TestCase):
         assert_equal(display_in_unit(10. * u.mV), '10. * mvolt')
         assert_equal(display_in_unit(10. * u.ohm * u.amp), '10. * volt')
         assert_equal(display_in_unit(120. * (u.mS / u.cm ** 2)), '120. * msiemens / cmeter2')
-        assert_equal(display_in_unit(3.0 * u.kmeter / 130.51 * u.meter), '0.02298675 * 10.0^3 * meter2')
-        assert_equal(display_in_unit(3.0 * u.kmeter / (130.51 * u.meter)), 'Quantity(22.986746)')
-        assert_equal(display_in_unit(3.0 * u.kmeter / 130.51 * u.meter * u.cm ** -2), 'Quantity(229867.45)')
-        assert_equal(display_in_unit(3.0 * u.kmeter / 130.51 * u.meter * u.cm ** -1), '0.02298675 * 10.0^5 * meter')
+        assert_equal(display_in_unit(3.0 * u.kmeter / 130.51 * u.meter), '0.02298674 * 10.0^3 * meter2')
+        assert_equal(display_in_unit(3.0 * u.kmeter / (130.51 * u.meter)), 'Quantity(22.986744)')
+        assert_equal(display_in_unit(3.0 * u.kmeter / 130.51 * u.meter * u.cm ** -2), 'Quantity(229867.44)')
+        assert_equal(display_in_unit(3.0 * u.kmeter / 130.51 * u.meter * u.cm ** -1), '0.02298674 * 10.0^5 * meter')
         assert_equal(display_in_unit(1. * u.joule / u.kelvin), '1. * joule / kelvin')
 
         assert_equal(str(1. * u.metre / ((3.0 * u.ms) / (1. * u.second))), '333.33334 * meter')

--- a/brainunit/_celsius_test.py
+++ b/brainunit/_celsius_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-
+import numpy as np
 
 import brainunit as u
 
@@ -22,7 +22,7 @@ def test1():
     assert a == 273.15 * u.kelvin
 
     b = u.celsius2kelvin(-100)
-    assert b == 173.15 * u.kelvin
+    assert u.math.allclose(b, 173.15 * u.kelvin)
 
 
 def test2():
@@ -30,4 +30,4 @@ def test2():
     assert a == 0
 
     b = u.kelvin2celsius(173.15 * u.kelvin)
-    assert b == -100
+    assert np.isclose(b, -100)

--- a/brainunit/constants_test.py
+++ b/brainunit/constants_test.py
@@ -81,5 +81,7 @@ class TestConstant(unittest.TestCase):
         for c in constants_list:
             q_c = getattr(quantity_constants, c)
             u_c = getattr(unit_constants, c)
-            assert q_c.to_decimal(q_c.unit) == (1. * u_c).to_decimal(
-                q_c.unit), f"Mismatch between {c} in quantity_constants and unit_constants"
+            assert u.math.isclose(
+                q_c.to_decimal(q_c.unit),
+                (1. * u_c).to_decimal(q_c.unit)
+            ), f"Mismatch between {c} in quantity_constants and unit_constants"


### PR DESCRIPTION
This pull request includes several changes to improve the handling of numerical operations and enhance the accuracy of unit tests in the `brainunit` package. The most important changes involve modifying the handling of numerical types, updating test assertions for better precision, and importing necessary libraries.

### Numerical operations improvements:

* [`brainunit/_base.py`](diffhunk://#diff-68f3b161fe7a5ee956cf1363f0ef9df0fda8ce903c36894fadc791ab363e9c57L2190-R2191): Updated the `__init__`, `tolist`, and `get` methods to handle numerical types more accurately and avoid unnecessary conversions. [[1]](diffhunk://#diff-68f3b161fe7a5ee956cf1363f0ef9df0fda8ce903c36894fadc791ab363e9c57L2190-R2191) [[2]](diffhunk://#diff-68f3b161fe7a5ee956cf1363f0ef9df0fda8ce903c36894fadc791ab363e9c57L3634-R3639) [[3]](diffhunk://#diff-68f3b161fe7a5ee956cf1363f0ef9df0fda8ce903c36894fadc791ab363e9c57L4057-R4062)

### Test precision enhancements:

* [`brainunit/_base_test.py`](diffhunk://#diff-9199ab763579fad8135030608ccb80ba262d9393ae15663e0678ee20c3fb9e91L110-R111): Modified assertions in `test_unit_with_factor` and `test_display` methods to use `u.math.isclose` for better precision in floating-point comparisons. [[1]](diffhunk://#diff-9199ab763579fad8135030608ccb80ba262d9393ae15663e0678ee20c3fb9e91L110-R111) [[2]](diffhunk://#diff-9199ab763579fad8135030608ccb80ba262d9393ae15663e0678ee20c3fb9e91L264-R267)
* [`brainunit/_celsius_test.py`](diffhunk://#diff-4d621599ce1c5b881c580e5bfa958af2b9cbe10b1639f1beb032e549c98704d7L25-R33): Updated assertions in `test1` and `test2` methods to use `u.math.allclose` and `np.isclose` for improved accuracy.
* [`brainunit/constants_test.py`](diffhunk://#diff-93286de42f2498e024ce3ad376dbaf887ae97eafddebb3338989ef8376f44b52L84-R87): Enhanced the `test_quantity_constants_and_unit_constants` method to use `u.math.isclose` for precise comparison of constants.

### Library imports:

* [`brainunit/_celsius_test.py`](diffhunk://#diff-4d621599ce1c5b881c580e5bfa958af2b9cbe10b1639f1beb032e549c98704d7L15-R15): Added an import for `numpy` to support the use of `np.isclose`.

## Summary by Sourcery

Fix quantity initialization for Python numbers and improve test assertions.

Bug Fixes:
- Fix issue where `Quantity` initialization did not correctly handle Python numbers.
- Improve the accuracy of floating-point comparisons in tests by using `u.math.isclose` and `np.isclose`.