### PR TITLE
Enable `Quantity` typing with syntax of `Quantity[unit]`

### DIFF
--- a/brainunit/_base.py
+++ b/brainunit/_base.py
@@ -20,7 +20,7 @@ import operator
 from contextlib import contextmanager
 from copy import deepcopy
 from functools import wraps, partial
-from typing import Union, Optional, Sequence, Callable, Tuple, Any, List, Dict, cast
+from typing import Union, Optional, Sequence, Callable, Tuple, Any, List, Dict, cast, TypeVar, Generic
 
 import jax
 import jax.numpy as jnp
@@ -73,6 +73,8 @@ StaticScalar = Union[
 PyTree = Any
 _all_slice = slice(None, None, None)
 compat_with_equinox = False
+A = TypeVar('A')
+
 
 
 def compatible_with_equinox(mode: bool = True):
@@ -2135,7 +2137,7 @@ def _element_not_quantity(x):
 
 
 @register_pytree_node_class
-class Quantity:
+class Quantity(Generic[A]):
     """
     The `Quantity` class represents a physical quantity with a mantissa and a unit.
     It is used to represent all physical quantities in ``BrainUnit``.

--- a/brainunit/_base_test.py
+++ b/brainunit/_base_test.py
@@ -13,15 +13,17 @@
 # limitations under the License.
 # ==============================================================================
 
+from __future__ import annotations
 
-import os
-import tempfile
-
-os.environ['JAX_TRACEBACK_FILTERING'] = 'off'
 import itertools
+import os
+import pickle
+import sys
+import tempfile
 import unittest
 import warnings
 from copy import deepcopy
+from typing import Union
 
 import brainstate as bst
 import jax
@@ -29,7 +31,6 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 from numpy.testing import assert_equal
-from typing import Union
 
 import brainunit as u
 from brainunit._base import (
@@ -49,7 +50,6 @@ from brainunit._base import (
 )
 from brainunit._unit_common import *
 from brainunit._unit_shortcuts import kHz, ms, mV, nS
-import pickle
 
 
 class TestDimension(unittest.TestCase):
@@ -902,6 +902,9 @@ class TestQuantity(unittest.TestCase):
         print(x.to(u.uvolt))
 
     def test_quantity_type(self):
+
+        # if sys.version_info >= (3, 11):
+
         def f1(a: u.Quantity[u.ms]) -> u.Quantity[u.mV]:
             return a
 

--- a/brainunit/_base_test.py
+++ b/brainunit/_base_test.py
@@ -29,6 +29,7 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 from numpy.testing import assert_equal
+from typing import Union
 
 import brainunit as u
 from brainunit._base import (
@@ -900,6 +901,16 @@ class TestQuantity(unittest.TestCase):
         print(x.to(u.volt))
         print(x.to(u.uvolt))
 
+    def test_quantity_type(self):
+        def f1(a: u.Quantity[u.ms]) -> u.Quantity[u.mV]:
+            return a
+
+        def f2(a: u.Quantity[Union[u.ms, u.mA]]) -> u.Quantity[u.mV]:
+            return a
+
+        def f3(a: u.Quantity[Union[u.ms, u.mA]]) -> u.Quantity[Union[u.mV, u.ms]]:
+            return a
+
 
 class TestNumPyFunctions(unittest.TestCase):
     def test_special_case_numpy_functions(self):
@@ -1466,12 +1477,6 @@ def test_pickle():
     with open(filename, "rb") as f:
         b = pickle.load(f)
         print(b)
-
-
-
-
-
-
 
 
 def test_str_repr():


### PR DESCRIPTION
This pull request introduces type variables and generics to the `Quantity` class in the `brainunit` module and includes corresponding tests. The changes enhance type safety and flexibility when working with quantities.

Code example:

```python
        def f1(a: u.Quantity[u.ms]) -> u.Quantity[u.ms]:
            return a
```

This enhance the readability of the Quantity typing.


### Type Enhancements:

* [`brainunit/_base.py`](diffhunk://#diff-68f3b161fe7a5ee956cf1363f0ef9df0fda8ce903c36894fadc791ab363e9c57L23-R23): Added `TypeVar` and `Generic` imports to enable the use of generics in the `Quantity` class.
* [`brainunit/_base.py`](diffhunk://#diff-68f3b161fe7a5ee956cf1363f0ef9df0fda8ce903c36894fadc791ab363e9c57R76-R77): Introduced a new type variable `A` to be used with the `Quantity` class.
* [`brainunit/_base.py`](diffhunk://#diff-68f3b161fe7a5ee956cf1363f0ef9df0fda8ce903c36894fadc791ab363e9c57L2138-R2140): Modified the `Quantity` class to inherit from `Generic[A]`, making it a generic class.

### Testing Enhancements:

* [`brainunit/_base_test.py`](diffhunk://#diff-9199ab763579fad8135030608ccb80ba262d9393ae15663e0678ee20c3fb9e91R904-R913): Added a new test `test_quantity_type` to verify the type safety and flexibility of the `Quantity` class with different type variables.
* [`brainunit/_base_test.py`](diffhunk://#diff-9199ab763579fad8135030608ccb80ba262d9393ae15663e0678ee20c3fb9e91L1471-L1476): Removed unnecessary blank lines in the `test_pickle` function for better code readability.