### PR TITLE
Add `environ` module and refactor unit handling

### DIFF
--- a/brainunit/__init__.py
+++ b/brainunit/__init__.py
@@ -18,6 +18,7 @@ __version__ = "0.0.4"
 from . import _matplotlib_compat
 from . import autograd
 from . import constants
+from . import environ
 from . import fft
 from . import lax
 from . import linalg
@@ -38,6 +39,7 @@ __all__ = (
         'math',
         'linalg',
         'autograd',
+        'environ',
         'fft',
         'constants',
         'sparse'

--- a/brainunit/_base.py
+++ b/brainunit/_base.py
@@ -4962,7 +4962,7 @@ def convert_in_si():
     This function traverses the local variables in the calling scope and converts all `Quantity`
     instances (including those nested in lists, tuples, or dictionaries) to their SI unit equivalents.
     The conversion is performed by calling the `factorless()` method on each `Quantity` instance,
-    which strips the unit and returns the raw value in SI units.
+    which convert the unit and returns the quantities in SI units.
 
     Notes:
         - This function modifies the local variables in the calling scope.

--- a/brainunit/_base_test.py
+++ b/brainunit/_base_test.py
@@ -776,7 +776,12 @@ class TestQuantity(unittest.TestCase):
         units = [volt, second, siemens, mV, kHz]
 
         # numpy functions
-        keep_dim_funcs = [np.argmin, np.argmax, np.argsort, np.nonzero]
+        keep_dim_funcs = [
+            np.argmin,
+            np.argmax,
+            # np.argsort, # TODO: after upgrading jax 0.5.0, argsort will raise an error
+            np.nonzero
+        ]
 
         for value, unit in itertools.product(values, units):
             q_ar = value * unit

--- a/brainunit/environ.py
+++ b/brainunit/environ.py
@@ -74,8 +74,6 @@ def context(**kwargs):
     if 'compute_mode' in kwargs:
         if kwargs['compute_mode'] == SI_MODE:
             _convert_to_si_quantity(**kwargs)
-        else:
-            pass
 
     try:
         for k, v in kwargs.items():

--- a/brainunit/environ.py
+++ b/brainunit/environ.py
@@ -110,9 +110,9 @@ def get(key: str, default: Any = _NOT_PROVIDE, desc: str = None):
     item: Any
       The default computation environment.
     """
-    if key in DEFAULT.contexts:
-        if len(DEFAULT.contexts[key]) > 0:
-            return DEFAULT.contexts[key][-1]
+    if key in DEFAULT.contexts and len(DEFAULT.contexts[key]) > 0:
+        return DEFAULT.contexts[key][-1]
+
     if key in DEFAULT.settings:
         return DEFAULT.settings[key]
 
@@ -142,7 +142,7 @@ def all() -> dict:
     r: dict
       The current default computation environment.
     """
-    r = dict()
+    r = {}
     for k, v in DEFAULT.contexts.items():
         if v:
             r[k] = v[-1]
@@ -177,7 +177,10 @@ def set(
         The default compute mode. Default is computing in 'si'.
     """
     if compute_mode is not None:
-        assert compute_mode in ['si', 'non_si'], f"compute_mode must be 'si' or 'non_si'. Got: {compute_mode}"
+        assert compute_mode in {
+            'si',
+            'non_si',
+        }, f"compute_mode must be 'si' or 'non_si'. Got: {compute_mode}"
         kwargs['compute_mode'] = compute_mode
 
     # set default environment

--- a/brainunit/environ.py
+++ b/brainunit/environ.py
@@ -1,0 +1,216 @@
+# Copyright 2024 BDP Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+# -*- coding: utf-8 -*-
+
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import functools
+import inspect
+import os
+import re
+import threading
+from collections import defaultdict
+from typing import Any, Callable, Dict, Hashable
+
+__all__ = [
+    # functions for environment settings
+    'set', 'context', 'get', 'all',
+    # functions for getting default behaviors
+    'get_compute_mode',
+    # constants
+    'SI_MODE', 'NON_SI_MODE'
+]
+
+SI_MODE: str = 'si'
+NON_SI_MODE: str = 'non_si'
+
+
+@dataclasses.dataclass
+class DefaultContext(threading.local):
+    # default environment settings
+    settings: Dict[Hashable, Any] = dataclasses.field(default_factory=dict)
+    # current environment settings
+    contexts: defaultdict[Hashable, Any] = dataclasses.field(default_factory=lambda: defaultdict(list))
+    # environment functions
+    functions: Dict[Hashable, Any] = dataclasses.field(default_factory=dict)
+
+DEFAULT = DefaultContext()
+_NOT_PROVIDE = object()
+
+
+@contextlib.contextmanager
+def context(**kwargs):
+    r"""
+    Context-manager that sets a computing environment for brainunit.
+
+    For instance::
+
+    >>> import brainunit as u
+    >>> global_1 = 2 * u.kmh
+    >>> global_2 = 0
+    >>> def create_a(a):
+    ...     return a.mantissa * 2 * u.minute
+    >>> with u.environ.context(compute_mode='si'):
+    ...     a = create_a([1, 2, 3] * u.minute)  # If input is [1, 2, 3] * u.second, the result would differ
+    ...     b = [4, 5, 6] * u.inch
+    ...     global_2 = (b / a) / global_1
+
+    """
+    if 'compute_mode' in kwargs:
+        if kwargs['compute_mode'] == SI_MODE:
+            _convert_to_si_quantity(**kwargs)
+        else:
+            pass
+
+    try:
+        for k, v in kwargs.items():
+
+            # update the current environment
+            DEFAULT.contexts[k].append(v)
+
+            # restore the environment functions
+            if k in DEFAULT.functions:
+                DEFAULT.functions[k](v)
+
+        # yield the current all environment information
+        yield all()
+    finally:
+
+        for k, v in kwargs.items():
+
+            # restore the current environment
+            DEFAULT.contexts[k].pop()
+
+            # restore the environment functions
+            if k in DEFAULT.functions:
+                DEFAULT.functions[k](get(k))
+
+
+def get(key: str, default: Any = _NOT_PROVIDE, desc: str = None):
+    """
+    Get one of the default computation environment.
+
+    Returns
+    -------
+    item: Any
+      The default computation environment.
+    """
+    if key in DEFAULT.contexts:
+        if len(DEFAULT.contexts[key]) > 0:
+            return DEFAULT.contexts[key][-1]
+    if key in DEFAULT.settings:
+        return DEFAULT.settings[key]
+
+    if default is _NOT_PROVIDE:
+        if desc is not None:
+            raise KeyError(
+                f"'{key}' is not found in the context. \n"
+                f"You can set it by `brainstate.share.context({key}=value)` "
+                f"locally or `brainstate.share.set({key}=value)` globally. \n"
+                f"Description: {desc}"
+            )
+        else:
+            raise KeyError(
+                f"'{key}' is not found in the context. \n"
+                f"You can set it by `brainstate.share.context({key}=value)` "
+                f"locally or `brainstate.share.set({key}=value)` globally."
+            )
+    return default
+
+
+def all() -> dict:
+    """
+    Get all the current default computation environment.
+
+    Returns
+    -------
+    r: dict
+      The current default computation environment.
+    """
+    r = dict()
+    for k, v in DEFAULT.contexts.items():
+        if v:
+            r[k] = v[-1]
+    for k, v in DEFAULT.settings.items():
+        if k not in r:
+            r[k] = v
+    return r
+
+
+def get_compute_mode() -> str:
+    """
+    Get the current compute mode.
+
+    Returns
+    -------
+    mode: str
+      The current compute mode.
+    """
+    return get('compute_mode')
+
+def set(
+    compute_mode: str = None,
+    **kwargs
+):
+    """
+    Set the global default computation environment.
+
+
+
+    Args:
+      compute_mode: str, optional
+        The default compute mode. Default is computing in 'si'.
+    """
+    if compute_mode is not None:
+        assert compute_mode in ['si', 'non_si'], f"compute_mode must be 'si' or 'non_si'. Got: {compute_mode}"
+        kwargs['compute_mode'] = compute_mode
+
+    # set default environment
+    DEFAULT.settings.update(kwargs)
+
+    # update the environment functions
+    for k, v in kwargs.items():
+        if k in DEFAULT.functions:
+            DEFAULT.functions[k](v)
+
+def _convert_to_si_quantity(**kwargs):
+    """
+                Convert all the local variables in SI units.
+
+                Traverses the local variables in the calling scope and converts all `Quantity`
+                instances (including those nested in lists, tuples, or dictionaries) to their SI unit equivalents.
+                The conversion is performed by calling the `factorless()` method on each `Quantity` instance,
+                which convert the unit and returns the quantities in SI units.
+                """
+    set(compute_mode=kwargs['compute_mode'])
+    from ._base import Quantity, Unit
+    frame = inspect.currentframe().f_back.f_back.f_back
+    original = {k: v for k, v in frame.f_locals.items()
+                if isinstance(v, (Quantity, Unit))}
+
+    try:
+        # Convert to SI
+        for k, v in original.items():
+            frame.f_locals[k] = v.factorless()
+        yield
+    finally:
+        # Restore original values
+        for k, v in original.items():
+            frame.f_locals[k] = v
+
+set(compute_mode=NON_SI_MODE)

--- a/brainunit/environ_test.py
+++ b/brainunit/environ_test.py
@@ -1,0 +1,37 @@
+# Copyright 2024 BDP Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import unittest
+
+import pytest
+import brainunit as u
+
+class TestEnviron(unittest.TestCase):
+    def test_compute_mode(self):
+        global_1 = 2 * u.kmh
+        global_2 = 0
+
+        def create_a(a):
+            return a.mantissa * 2 * u.minute
+
+        with u.environ.context(compute_mode='si'):
+            a = create_a([1, 2, 3] * u.minute)  # If input is [1, 2, 3] * u.second, the result would differ
+            b = [4, 5, 6] * u.inch
+            global_2 = (b / a) / global_1
+
+            assert a.unit.factor == 1.
+            assert b.unit.factor == 1.
+            # TODO: need to fix compound standard units
+            # assert global_1.unit.factor == 1.

--- a/brainunit/math/_einops.py
+++ b/brainunit/math/_einops.py
@@ -1212,11 +1212,6 @@ def einsum(
 
     .. _opt_einsum: https://github.com/dgasmith/opt_einsum
     """
-    # operands = jax.tree.map(
-    #     lambda x: x.factorless() if isinstance(x, Quantity) else x,
-    #     operands,
-    #     is_leaf=lambda x: isinstance(x, Quantity)
-    # )
 
     operands = (subscripts, *operands)
     spec = operands[0] if isinstance(operands[0], str) else None

--- a/brainunit/math/_fun_accept_unitless.py
+++ b/brainunit/math/_fun_accept_unitless.py
@@ -52,7 +52,7 @@ def _fun_accept_unitless_unary(
     **kwargs
 ):
     if isinstance(x, Quantity):
-        # x = x.factorless()
+
         if unit_to_scale is None:
             assert x.dim.is_dimensionless, (
                 f'{func} only support dimensionless input. But we got {x}. \n'
@@ -772,7 +772,7 @@ def _fun_accept_unitless_binary(
     **kwargs
 ):
     if isinstance(x, Quantity):
-        # x = x.factorless()
+
         if unit_to_scale is None:
             assert x.dim.is_dimensionless, (
                 f'{func} only support dimensionless input. But we got {x}. \n'
@@ -784,7 +784,7 @@ def _fun_accept_unitless_binary(
             assert isinstance(unit_to_scale, Unit), f'unit_to_scale should be a Unit instance. Got {unit_to_scale}'
             x = x.to_decimal(unit_to_scale)
     if isinstance(y, Quantity):
-        # y = y.factorless()
+
         if unit_to_scale is None:
             assert y.dim.is_dimensionless, (f'Input should be dimensionless for the function "{func}" '
                                             f'when scaling "unit_to_scale" is not provided.')
@@ -1145,11 +1145,9 @@ def invert(
 
 def _fun_unitless_binary(func, x, y, *args, **kwargs):
     if isinstance(x, Quantity):
-        # x = x.factorless()
         assert x.dim.is_dimensionless, f'Expected dimensionless array, got {x}'
         x = x.to_decimal()
     if isinstance(y, Quantity):
-        # y = y.factorless()
         assert y.dim.is_dimensionless, f'Expected dimensionless array, got {y}'
         y = y.to_decimal()
     return func(x, y, *args, **kwargs)

--- a/brainunit/math/_fun_change_unit.py
+++ b/brainunit/math/_fun_change_unit.py
@@ -46,7 +46,6 @@ __all__ = [
 
 def _fun_change_unit_unary(val_fun, unit_fun, x, *args, **kwargs):
     if isinstance(x, Quantity):
-        # x = x.factorless()
         r = Quantity(val_fun(x.mantissa, *args, **kwargs), unit=unit_fun(x.unit))
         return maybe_decimal(r)
     return val_fun(x, *args, **kwargs)
@@ -517,18 +516,17 @@ cumproduct = cumprod
 
 def _fun_change_unit_binary(val_fun, unit_fun, x, y, *args, **kwargs):
     if isinstance(x, Quantity) and isinstance(y, Quantity):
-        # x = x.factorless()
-        # y = y.factorless()
+
         return maybe_decimal(
             Quantity(val_fun(x.mantissa, y.mantissa, *args, **kwargs), unit=unit_fun(x.unit, y.unit))
         )
     elif isinstance(x, Quantity):
-        # x = x.factorless()
+
         return maybe_decimal(
             Quantity(val_fun(x.mantissa, y, *args, **kwargs), unit=unit_fun(x.unit, UNITLESS))
         )
     elif isinstance(y, Quantity):
-        # y = y.factorless()
+
         return maybe_decimal(
             Quantity(val_fun(x, y.mantissa, *args, **kwargs), unit=unit_fun(UNITLESS, y.unit))
         )

--- a/brainunit/math/_fun_keep_unit.py
+++ b/brainunit/math/_fun_keep_unit.py
@@ -83,11 +83,6 @@ def _fun_keep_unit_sequence(
     **kwargs
 ):
     leaves, treedef = jax.tree.flatten(args, is_leaf=lambda x: isinstance(x, Quantity))
-    # leaves = jax.tree.map(
-    #     lambda x: x.factorless() if isinstance(x, Quantity) else x,
-    #     leaves,
-    #     is_leaf=lambda x: isinstance(x, Quantity)
-    # )
     leaves = unit_scale_align_to_first(*leaves)
     unit = leaves[0].unit
     leaves = [x.mantissa for x in leaves]

--- a/brainunit/math/_fun_remove_unit.py
+++ b/brainunit/math/_fun_remove_unit.py
@@ -67,7 +67,7 @@ def get_promote_dtypes(
 
 def _fun_remove_unit_unary(func, x, *args, **kwargs):
     if isinstance(x, Quantity):
-        # x = x.factorless()
+
         return func(x.mantissa, *args, **kwargs)
     else:
         return func(x, *args, **kwargs)
@@ -374,15 +374,14 @@ sometrue = any
 
 def _fun_logic_binary(func, x, y, *args, **kwargs):
     if isinstance(x, Quantity) and isinstance(y, Quantity):
-        # x = x.factorless()
-        # y = y.factorless()
+
         return func(x.mantissa, y.in_unit(x.unit).mantissa, *args, **kwargs)
     elif isinstance(x, Quantity):
-        # x = x.factorless()
+
         assert x.is_unitless, f'Expected unitless array when y is not Quantity, while got {x}'
         return func(x.mantissa, y, *args, **kwargs)
     elif isinstance(y, Quantity):
-        # y = y.factorless()
+
         assert y.is_unitless, f'Expected unitless array when x is not Quantity, while got {y}'
         return func(x, y.mantissa, *args, **kwargs)
     else:


### PR DESCRIPTION
## Summary by Sourcery

Introduce the `environ` module to enable switching between SI and non-SI computation modes. Remove commented-out code blocks for enhanced readability and maintainability.

New Features:
- Add `environ` module to control computation in SI or non-SI units.

Tests:
- Update tests to accommodate the new `environ` module and computation modes.